### PR TITLE
Add web/serve access modes and Gitea MCP integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ SSH_PUBLIC_KEY=              # Your SSH public key (contents of ~/.ssh/id_ed2551
 SSH_PASSWORD=                # Fallback password for SSH (if no key provided)
 SSH_PORT=2222                # Host port mapped to container SSH (default: 2222)
 
+# System Configuration
+TZ=                          # Timezone (e.g., America/New_York, Europe/London, Asia/Tokyo)
+
 # Git Configuration
 GIT_REPO_URL=                # Repository to clone on startup (e.g., https://github.com/user/repo.git)
 GIT_BRANCH=                  # Branch to checkout (default: repo default branch)

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# SSH Access Configuration
+SSH_PUBLIC_KEY=              # Your SSH public key (contents of ~/.ssh/id_ed25519.pub)
+SSH_PASSWORD=                # Fallback password for SSH (if no key provided)
+SSH_PORT=2222                # Host port mapped to container SSH (default: 2222)
+
+# Git Configuration
+GIT_REPO_URL=                # Repository to clone on startup (e.g., https://github.com/user/repo.git)
+GIT_BRANCH=                  # Branch to checkout (default: repo default branch)
+GIT_USER_NAME=               # Git user.name for commits
+GIT_USER_EMAIL=              # Git user.email for commits
+
+# OpenCode Configuration
+OPENCODE_CONFIG_JSON=        # Full opencode.json contents (overrides default config)
+
+# AI Provider API Keys (optional - set these if not using OpenCode Go)
+ANTHROPIC_API_KEY=           # Anthropic API key
+OPENAI_API_KEY=              # OpenAI API key
+GOOGLE_API_KEY=              # Google Gemini API key
+OPENROUTER_API_KEY=          # OpenRouter API key
+
+# GitHub CLI (optional)
+GITHUB_TOKEN=                # GitHub personal access token for gh CLI

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ SSH_PORT=2222                # Host port mapped to container SSH (default: 2222)
 # System Configuration
 TZ=                          # Timezone (e.g., America/New_York, Europe/London, Asia/Tokyo)
 
+# OpenCode Access Mode
+OPENCODE_MODE=ssh            # Access mode: ssh, web, or serve (default: ssh)
+OPENCODE_PORT=4096           # Port for web/serve modes (default: 4096)
+OPENCODE_SERVER_PASSWORD=    # HTTP Basic Auth password for web/serve modes
+OPENCODE_SERVER_USERNAME=    # HTTP Basic Auth username (default: opencode)
+
 # Git Configuration
 GIT_REPO_URL=                # Repository to clone on startup (e.g., https://github.com/user/repo.git)
 GIT_BRANCH=                  # Branch to checkout (default: repo default branch)
@@ -23,3 +29,7 @@ OPENROUTER_API_KEY=          # OpenRouter API key
 
 # GitHub CLI (optional)
 GITHUB_TOKEN=                # GitHub personal access token for gh CLI
+
+# Gitea Integration (optional)
+GITEA_URL=                   # Gitea instance URL (e.g., https://gitea.example.com)
+GITEA_TOKEN=                 # Gitea personal access token

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+*.pem
+*.key
+id_rsa*
+auth.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+# System packages + openssh-server
+RUN apt-get update && apt-get install -y \
+    openssh-server sudo git curl wget unzip build-essential \
+    python3 python3-pip python3-venv \
+    jq ripgrep fd-find tmux vim nano less htop \
+    ca-certificates gnupg locales openssl \
+    && locale-gen en_US.UTF-8 \
+    && mkdir -p /run/sshd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22.x via NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Go 1.23.x
+RUN curl -fsSL https://go.dev/dl/go1.23.6.linux-amd64.tar.gz | tar -C /usr/local -xz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Create non-root user
+RUN useradd -m -s /bin/bash -u 1000 coder \
+    && echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/coder \
+    && chmod 0440 /etc/sudoers.d/coder
+
+# Install opencode as coder user
+USER coder
+WORKDIR /home/coder
+RUN curl -fsSL https://opencode.ai/install | bash
+ENV PATH="/home/coder/.local/bin:${PATH}"
+
+# Go path for coder
+ENV GOPATH="/home/coder/go"
+ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
+
+# Create directories for persistence
+RUN mkdir -p /home/coder/.config/opencode \
+    /home/coder/.local/share/opencode \
+    /home/coder/.ssh \
+    /home/coder/workspace
+
+USER root
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 22
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,12 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
 RUN curl -fsSL "https://go.dev/dl/go1.23.6.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
+# Install Gitea MCP server (official Go binary)
+ENV GOPATH="/tmp/go-build"
+RUN go install gitea.com/gitea/gitea-mcp@latest \
+    && cp "${GOPATH}/bin/gitea-mcp" /usr/local/bin/gitea-mcp \
+    && rm -rf "${GOPATH}"
+
 # Create non-root user
 RUN useradd -m -s /bin/bash -u 1000 coder \
     && echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/coder \
@@ -66,7 +72,7 @@ RUN mkdir -p /etc/skel.coder/.config/opencode \
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-EXPOSE 22
+EXPOSE 22 4096
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD ssh-keyscan -p 22 localhost >/dev/null 2>&1 || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+ARG TARGETARCH=amd64
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
@@ -10,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     openssh-server sudo git curl wget unzip build-essential \
     python3 python3-pip python3-venv \
     jq ripgrep fd-find tmux vim nano less htop \
-    ca-certificates gnupg locales openssl \
+    ca-certificates gnupg locales openssl tzdata \
     && locale-gen en_US.UTF-8 \
     && mkdir -p /run/sshd \
     && rm -rf /var/lib/apt/lists/*
@@ -30,8 +32,8 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Go 1.23.x
-RUN curl -fsSL https://go.dev/dl/go1.23.6.linux-amd64.tar.gz | tar -C /usr/local -xz
+# Go 1.23.x (multi-arch)
+RUN curl -fsSL "https://go.dev/dl/go1.23.6.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Create non-root user
@@ -49,16 +51,24 @@ ENV PATH="/home/coder/.local/bin:${PATH}"
 ENV GOPATH="/home/coder/go"
 ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
 
-# Create directories for persistence
-RUN mkdir -p /home/coder/.config/opencode \
-    /home/coder/.local/share/opencode \
-    /home/coder/.ssh \
-    /home/coder/workspace
-
+# Create skeleton directory for first-boot home initialization
 USER root
+RUN mkdir -p /etc/skel.coder/.config/opencode \
+    /etc/skel.coder/.local/share/opencode \
+    /etc/skel.coder/.local/bin \
+    /etc/skel.coder/.ssh \
+    /etc/skel.coder/workspace \
+    /etc/skel.coder/go \
+    && cp -a /home/coder/.local/bin/. /etc/skel.coder/.local/bin/ 2>/dev/null || true \
+    && cp -a /home/coder/.bashrc /etc/skel.coder/.bashrc 2>/dev/null || true \
+    && cp -a /home/coder/.profile /etc/skel.coder/.profile 2>/dev/null || true
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 EXPOSE 22
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ssh-keyscan -p 22 localhost >/dev/null 2>&1 || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The `docker-compose.yml` references `dokploy-network` as an external network. Th
 
 5. A URL will be displayed — open it in your local browser, complete the authentication, and paste the resulting key back into the terminal
 
-6. Your credentials are stored in `~/.local/share/opencode/` which is persisted via the `opencode-auth` Docker volume — they survive container restarts and redeployments.
+6. Your credentials are stored in `~/.local/share/opencode/` which is persisted via the `coder-home` Docker volume — they survive container restarts and redeployments.
 
 ## Alternative: API Keys
 
@@ -99,6 +99,8 @@ Set `SSH_PUBLIC_KEY` in your `.env` to the contents of your public key:
 SSH_PUBLIC_KEY="ssh-ed25519 AAAAC3... user@machine"
 ```
 
+When only a key is provided (no `SSH_PASSWORD`), password authentication is automatically disabled for improved security.
+
 Then connect:
 ```bash
 ssh coder@your-server -p 2222
@@ -111,6 +113,10 @@ Set `SSH_PASSWORD` in your `.env`:
 ```bash
 SSH_PASSWORD=your-secure-password
 ```
+
+### Both Key and Password
+
+If both `SSH_PUBLIC_KEY` and `SSH_PASSWORD` are set, both authentication methods are enabled.
 
 ### No Credentials Set
 
@@ -142,7 +148,7 @@ cd ~/workspace
 git clone https://github.com/user/repo.git
 ```
 
-The `~/workspace` directory is backed by the `workspace` Docker volume and persists across restarts.
+The `~/workspace` directory is part of the `coder-home` volume and persists across restarts.
 
 ### Git Identity
 
@@ -180,10 +186,28 @@ OPENCODE_CONFIG_JSON='{"$schema":"https://opencode.ai/config.json","provider":"a
 
 ### Edit Directly
 
-The config file is persisted in the `opencode-config` volume. SSH in and edit it:
+The config file is persisted in the `coder-home` volume. SSH in and edit it:
 
 ```bash
 nano ~/.config/opencode/opencode.json
+```
+
+## Timezone
+
+By default the container runs in UTC. Set the `TZ` environment variable to use a different timezone:
+
+```bash
+TZ=America/New_York
+```
+
+This affects system logs, git commit timestamps, and all time-related operations. See [the full list of timezone names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+## Multi-Architecture Support
+
+The Docker image supports both **amd64** (x86_64) and **arm64** (aarch64) architectures. The correct Go binary is automatically selected during the build based on the target platform. To build for a specific architecture:
+
+```bash
+docker buildx build --platform linux/arm64 -t opencode-agent .
 ```
 
 ## Included Development Tools
@@ -211,17 +235,24 @@ The `coder` user has passwordless `sudo` access, so you can install additional t
 sudo apt-get update && sudo apt-get install -y <package>
 ```
 
-Note: Packages installed via `sudo` will not persist across container restarts. To make them permanent, add them to the `Dockerfile`.
+Note: Packages installed via `sudo` are now persisted across restarts thanks to the `coder-home` volume. However, they will not survive a full image rebuild — to make them permanent across rebuilds, add them to the `Dockerfile`.
 
 ## Volume Reference
 
 | Volume | Container Path | Purpose |
 |--------|---------------|---------|
-| `opencode-auth` | `/home/coder/.local/share/opencode` | OpenCode authentication credentials and session data |
-| `opencode-config` | `/home/coder/.config/opencode` | OpenCode configuration (`opencode.json`) |
-| `workspace` | `/home/coder/workspace` | Cloned repositories and project files |
+| `coder-home` | `/home/coder` | Entire home directory — config, auth, workspace, bash history, installed tools, dotfiles |
+| `ssh-host-keys` | `/etc/ssh/host_keys` | SSH host keys — prevents "host key changed" warnings after restarts |
 
-All three volumes are Docker named volumes, which persist data across container restarts, rebuilds, and redeployments.
+Both volumes are Docker named volumes, which persist data across container restarts, rebuilds, and redeployments.
+
+### First-boot Initialization
+
+On first start (when the `coder-home` volume is empty), the entrypoint copies a skeleton directory into `/home/coder` with the opencode binary and default directory structure. Subsequent starts reuse the existing home directory contents.
+
+### Health Check
+
+The container includes a Docker HEALTHCHECK that verifies the SSH daemon is accepting connections. Docker and Dokploy will report the container as `healthy` once SSH is ready, and will flag it as `unhealthy` if the SSH daemon becomes unresponsive.
 
 ## Environment Variables
 
@@ -230,6 +261,7 @@ All three volumes are Docker named volumes, which persist data across container 
 | `SSH_PUBLIC_KEY` | No* | — | SSH public key for key-based auth |
 | `SSH_PASSWORD` | No* | — | Password for SSH password auth |
 | `SSH_PORT` | No | `2222` | Host port mapped to container SSH |
+| `TZ` | No | `UTC` | Timezone (e.g., `America/New_York`) |
 | `GIT_REPO_URL` | No | — | Repository URL to clone on startup |
 | `GIT_BRANCH` | No | — | Branch to checkout (default: repo default) |
 | `GIT_USER_NAME` | No | — | Git commit author name |
@@ -241,7 +273,7 @@ All three volumes are Docker named volumes, which persist data across container 
 | `OPENROUTER_API_KEY` | No | — | OpenRouter API key |
 | `GITHUB_TOKEN` | No | — | GitHub PAT for `gh` CLI |
 
-\* At least one of `SSH_PUBLIC_KEY` or `SSH_PASSWORD` is recommended. If neither is set, a random password is generated and logged.
+\* At least one of `SSH_PUBLIC_KEY` or `SSH_PASSWORD` is recommended. If neither is set, a random password is generated and logged. When only `SSH_PUBLIC_KEY` is set, password authentication is disabled automatically.
 
 ## Troubleshooting
 
@@ -252,9 +284,20 @@ All three volumes are Docker named volumes, which persist data across container 
 - Ensure your firewall allows the SSH port
 - On Dokploy, confirm the port is configured in the Ports settings
 
+### "Host key changed" warning after rebuild
+
+If you see `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED`, the SSH host keys were regenerated. This should not happen during normal restarts (keys are persisted in the `ssh-host-keys` volume), but can occur if:
+- The `ssh-host-keys` volume was deleted
+- You rebuilt with `docker compose down -v`
+
+Fix: Remove the old host key from your local `~/.ssh/known_hosts`:
+```bash
+ssh-keygen -R "[localhost]:2222"
+```
+
 ### Authentication credentials lost after restart
 
-- Verify the `opencode-auth` volume exists: `docker volume ls | grep opencode-auth`
+- Verify the `coder-home` volume exists: `docker volume ls | grep coder-home`
 - Ensure you're not using `docker compose down -v` (the `-v` flag deletes volumes)
 
 ### opencode command not found

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCode Docker Container for Dokploy
 
-A Docker container running [opencode](https://opencode.ai) — an open-source AI coding agent with a terminal UI — accessible via SSH. Designed for 24/7 deployment on [Dokploy](https://dokploy.com) (self-hosted PaaS) or any Docker host.
+A Docker container running [opencode](https://opencode.ai) — an open-source AI coding agent with a terminal UI — accessible via SSH, web browser, or remote TUI client. Designed for 24/7 deployment on [Dokploy](https://dokploy.com) (self-hosted PaaS) or any Docker host.
 
 ## Quick Start
 
@@ -23,6 +23,68 @@ ssh coder@localhost -p 2222
 opencode
 ```
 
+## Access Modes
+
+The container supports three access modes, controlled by the `OPENCODE_MODE` environment variable:
+
+### SSH Mode (default)
+
+```bash
+OPENCODE_MODE=ssh
+```
+
+Traditional SSH access. Connect via SSH and run `opencode` interactively in your terminal. SSH is always available in all modes.
+
+### Web Mode
+
+```bash
+OPENCODE_MODE=web
+```
+
+Starts the opencode web UI — a full browser-based interface for interacting with the AI agent. Access it at:
+
+```
+http://your-server-ip:4096
+```
+
+SSH remains available in the background for troubleshooting.
+
+### Serve Mode
+
+```bash
+OPENCODE_MODE=serve
+```
+
+Starts a headless HTTP API server (REST + SSE). This allows:
+
+- **Remote TUI** — Connect a local opencode terminal client to the remote server:
+  ```bash
+  opencode attach http://your-server-ip:4096
+  ```
+- **Multiple clients** — Several browsers or TUI clients can connect simultaneously to the same server, sharing session state
+- **API access** — Full REST API with OpenAPI 3.1 spec available at `/doc`
+
+SSH remains available in the background.
+
+### Authentication for Web/Serve Modes
+
+Protect your web/serve endpoint with HTTP Basic Auth:
+
+```bash
+OPENCODE_SERVER_PASSWORD=your-secure-password
+OPENCODE_SERVER_USERNAME=opencode   # optional, defaults to "opencode"
+```
+
+These env vars are read directly by opencode. When set, browsers will show a native login dialog and `opencode attach` clients should set `OPENCODE_SERVER_PASSWORD` locally.
+
+### Port Configuration
+
+The web/serve port defaults to `4096`. Change it with:
+
+```bash
+OPENCODE_PORT=8080
+```
+
 ## Dokploy Deployment
 
 ### Step-by-step
@@ -35,17 +97,25 @@ opencode
 2. **Set environment variables** in Dokploy's Environment tab:
    - `SSH_PUBLIC_KEY` — your public key for SSH access
    - `SSH_PORT` — the host port for SSH (default: `2222`)
+   - `OPENCODE_MODE` — set to `web` or `serve` for browser/remote access
    - Any API keys you need (see [Environment Variables](#environment-variables))
 
-3. **Expose the SSH port**:
-   - In Dokploy's **Ports** settings, ensure the SSH port (default `2222`) is exposed
-   - This is a TCP port, not HTTP — it cannot go through Traefik's HTTP proxy
+3. **Expose ports**:
+   - SSH port (default `2222`) — TCP port, cannot go through Traefik
+   - OpenCode port (default `4096`) — HTTP port, can be proxied through Traefik for web/serve modes
 
 4. **Deploy** the service
 
-5. **Connect via SSH**:
+5. **Connect**:
    ```bash
+   # SSH
    ssh coder@your-server-ip -p 2222
+
+   # Browser (web mode)
+   open http://your-server-ip:4096
+
+   # Remote TUI (serve mode)
+   opencode attach http://your-server-ip:4096
    ```
 
 ### Network Note
@@ -159,6 +229,37 @@ GIT_USER_NAME="Your Name"
 GIT_USER_EMAIL="you@example.com"
 ```
 
+## Gitea Integration
+
+The container includes the [official Gitea MCP server](https://gitea.com/gitea/gitea-mcp), pre-installed as a Go binary. When configured, this gives the AI agent direct access to your Gitea instance — it can manage repositories, issues, pull requests, branches, releases, and more.
+
+### Setup
+
+Set these environment variables:
+
+```bash
+GITEA_URL=https://gitea.example.com    # Your Gitea instance URL
+GITEA_TOKEN=your-personal-access-token  # Gitea PAT with appropriate scopes
+```
+
+On startup, the entrypoint automatically injects the Gitea MCP server configuration into `opencode.json`. The AI agent will have access to Gitea tools in its next session.
+
+### Generating a Gitea Token
+
+1. Go to your Gitea instance → **Settings** → **Applications** → **Access Tokens**
+2. Create a new token with the scopes you need (e.g., `repo`, `issue`, `admin:org`)
+3. Copy the token into `GITEA_TOKEN`
+
+### What the Agent Can Do
+
+With the Gitea MCP server, the AI agent can:
+- Create, list, and manage repositories
+- Create, edit, and search issues
+- Manage pull requests and code reviews
+- Work with branches, tags, and releases
+- Search code across repositories
+- Manage organizations and teams
+
 ## Customizing OpenCode Config
 
 ### Default Config
@@ -220,6 +321,7 @@ docker buildx build --platform linux/arm64 -t opencode-agent .
 | **Go** | 1.23.6 | Official binary |
 | **Git** | System | |
 | **GitHub CLI (gh)** | Latest | Authenticate with `GITHUB_TOKEN` env var |
+| **Gitea MCP** | Latest | Official Go binary, auto-configured via env vars |
 | **build-essential** | System | gcc, g++, make |
 | **ripgrep (rg)** | System | Fast file search |
 | **fd-find (fd)** | System | Fast file finder |
@@ -262,6 +364,10 @@ The container includes a Docker HEALTHCHECK that verifies the SSH daemon is acce
 | `SSH_PASSWORD` | No* | — | Password for SSH password auth |
 | `SSH_PORT` | No | `2222` | Host port mapped to container SSH |
 | `TZ` | No | `UTC` | Timezone (e.g., `America/New_York`) |
+| `OPENCODE_MODE` | No | `ssh` | Access mode: `ssh`, `web`, or `serve` |
+| `OPENCODE_PORT` | No | `4096` | Port for web/serve modes |
+| `OPENCODE_SERVER_PASSWORD` | No | — | HTTP Basic Auth password for web/serve |
+| `OPENCODE_SERVER_USERNAME` | No | `opencode` | HTTP Basic Auth username for web/serve |
 | `GIT_REPO_URL` | No | — | Repository URL to clone on startup |
 | `GIT_BRANCH` | No | — | Branch to checkout (default: repo default) |
 | `GIT_USER_NAME` | No | — | Git commit author name |
@@ -272,6 +378,8 @@ The container includes a Docker HEALTHCHECK that verifies the SSH daemon is acce
 | `GOOGLE_API_KEY` | No | — | Google Gemini API key |
 | `OPENROUTER_API_KEY` | No | — | OpenRouter API key |
 | `GITHUB_TOKEN` | No | — | GitHub PAT for `gh` CLI |
+| `GITEA_URL` | No | — | Gitea instance URL |
+| `GITEA_TOKEN` | No | — | Gitea personal access token |
 
 \* At least one of `SSH_PUBLIC_KEY` or `SSH_PASSWORD` is recommended. If neither is set, a random password is generated and logged. When only `SSH_PUBLIC_KEY` is set, password authentication is disabled automatically.
 
@@ -283,6 +391,19 @@ The container includes a Docker HEALTHCHECK that verifies the SSH daemon is acce
 - Check container logs: `docker compose logs opencode`
 - Ensure your firewall allows the SSH port
 - On Dokploy, confirm the port is configured in the Ports settings
+
+### Web UI not accessible
+
+- Verify `OPENCODE_MODE=web` is set in your `.env`
+- Check the port is exposed: `docker compose ps` should show `0.0.0.0:4096->4096/tcp`
+- Check container logs: `docker compose logs opencode`
+- Ensure your firewall allows port 4096 (or your custom `OPENCODE_PORT`)
+
+### Cannot attach remote TUI
+
+- Verify `OPENCODE_MODE=serve` is set
+- Ensure the port is reachable from your local machine
+- If auth is enabled, set `OPENCODE_SERVER_PASSWORD` on your local machine before running `opencode attach`
 
 ### "Host key changed" warning after rebuild
 
@@ -315,6 +436,13 @@ ssh-keygen -R "[localhost]:2222"
 - Verify `GIT_REPO_URL` is accessible from the container
 - For private repos, ensure SSH keys or tokens are configured
 - Check logs for specific git error messages
+
+### Gitea MCP not working
+
+- Verify both `GITEA_URL` and `GITEA_TOKEN` are set
+- Check that the token has appropriate scopes in your Gitea instance
+- Inspect the generated config: `cat ~/.config/opencode/opencode.json`
+- Check container logs for "Gitea MCP server configured" message
 
 ### Dokploy network not found
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,280 @@
-# agent-container
+# OpenCode Docker Container for Dokploy
+
+A Docker container running [opencode](https://opencode.ai) — an open-source AI coding agent with a terminal UI — accessible via SSH. Designed for 24/7 deployment on [Dokploy](https://dokploy.com) (self-hosted PaaS) or any Docker host.
+
+## Quick Start
+
+```bash
+# 1. Clone this repo
+git clone https://github.com/Du7chManiac/agent-container.git
+cd agent-container
+
+# 2. Configure environment
+cp .env.example .env
+# Edit .env — at minimum set SSH_PUBLIC_KEY or SSH_PASSWORD
+
+# 3. Start the container
+docker compose up -d
+
+# 4. SSH into the container
+ssh coder@localhost -p 2222
+
+# 5. Launch opencode
+opencode
+```
+
+## Dokploy Deployment
+
+### Step-by-step
+
+1. **Create a Compose service** in Dokploy:
+   - Go to your Dokploy dashboard
+   - Create a new **Compose** project
+   - Point it to this repository (or paste the `docker-compose.yml` contents)
+
+2. **Set environment variables** in Dokploy's Environment tab:
+   - `SSH_PUBLIC_KEY` — your public key for SSH access
+   - `SSH_PORT` — the host port for SSH (default: `2222`)
+   - Any API keys you need (see [Environment Variables](#environment-variables))
+
+3. **Expose the SSH port**:
+   - In Dokploy's **Ports** settings, ensure the SSH port (default `2222`) is exposed
+   - This is a TCP port, not HTTP — it cannot go through Traefik's HTTP proxy
+
+4. **Deploy** the service
+
+5. **Connect via SSH**:
+   ```bash
+   ssh coder@your-server-ip -p 2222
+   ```
+
+### Network Note
+
+The `docker-compose.yml` references `dokploy-network` as an external network. This network is automatically created by Dokploy. If running standalone without Dokploy, either:
+- Create it manually: `docker network create dokploy-network`
+- Or remove the `networks` section from `docker-compose.yml`
+
+## Authentication with OpenCode Go
+
+[OpenCode Go](https://opencode.ai) ($10/month) provides access to multiple AI models without needing individual API keys.
+
+1. SSH into the container:
+   ```bash
+   ssh coder@your-server -p 2222
+   ```
+
+2. Start opencode:
+   ```bash
+   opencode
+   ```
+
+3. Run the `/connect` command in the opencode TUI
+
+4. Select **OpenCode Go** as the provider
+
+5. A URL will be displayed — open it in your local browser, complete the authentication, and paste the resulting key back into the terminal
+
+6. Your credentials are stored in `~/.local/share/opencode/` which is persisted via the `opencode-auth` Docker volume — they survive container restarts and redeployments.
+
+## Alternative: API Keys
+
+If you prefer using your own API keys instead of OpenCode Go, set them as environment variables:
+
+```bash
+# In your .env file
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+GOOGLE_API_KEY=AI...
+```
+
+These are passed into the container and opencode will detect them automatically.
+
+## SSH Access
+
+### Key-based Authentication (Recommended)
+
+Set `SSH_PUBLIC_KEY` in your `.env` to the contents of your public key:
+
+```bash
+SSH_PUBLIC_KEY="ssh-ed25519 AAAAC3... user@machine"
+```
+
+Then connect:
+```bash
+ssh coder@your-server -p 2222
+```
+
+### Password Authentication
+
+Set `SSH_PASSWORD` in your `.env`:
+
+```bash
+SSH_PASSWORD=your-secure-password
+```
+
+### No Credentials Set
+
+If neither `SSH_PUBLIC_KEY` nor `SSH_PASSWORD` is configured, the entrypoint generates a random password and prints it to the container logs. Check with:
+
+```bash
+docker compose logs opencode
+```
+
+## Repository Management
+
+### Auto-clone on Startup
+
+Set `GIT_REPO_URL` to automatically clone a repository when the container starts:
+
+```bash
+GIT_REPO_URL=https://github.com/user/repo.git
+GIT_BRANCH=main  # optional
+```
+
+The clone is idempotent — if the directory already exists (from a previous run), it is skipped.
+
+### Manual Cloning
+
+SSH in and clone repos into `~/workspace/`:
+
+```bash
+cd ~/workspace
+git clone https://github.com/user/repo.git
+```
+
+The `~/workspace` directory is backed by the `workspace` Docker volume and persists across restarts.
+
+### Git Identity
+
+Set your commit identity via environment variables:
+
+```bash
+GIT_USER_NAME="Your Name"
+GIT_USER_EMAIL="you@example.com"
+```
+
+## Customizing OpenCode Config
+
+### Default Config
+
+On first start, if no config exists, the container creates `~/.config/opencode/opencode.json` with full permissions:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "*": "allow"
+  }
+}
+```
+
+This grants opencode permission to execute all tools without prompting.
+
+### Override via Environment Variable
+
+Set `OPENCODE_CONFIG_JSON` to a full JSON config string to override the default:
+
+```bash
+OPENCODE_CONFIG_JSON='{"$schema":"https://opencode.ai/config.json","provider":"anthropic","model":"claude-sonnet-4-20250514","permission":{"*":"allow"}}'
+```
+
+### Edit Directly
+
+The config file is persisted in the `opencode-config` volume. SSH in and edit it:
+
+```bash
+nano ~/.config/opencode/opencode.json
+```
+
+## Included Development Tools
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| **Node.js** | 22.x LTS | Via NodeSource |
+| **npm** | Bundled with Node.js | |
+| **Python 3** | System (3.12) | With pip and venv |
+| **Go** | 1.23.6 | Official binary |
+| **Git** | System | |
+| **GitHub CLI (gh)** | Latest | Authenticate with `GITHUB_TOKEN` env var |
+| **build-essential** | System | gcc, g++, make |
+| **ripgrep (rg)** | System | Fast file search |
+| **fd-find (fd)** | System | Fast file finder |
+| **jq** | System | JSON processor |
+| **tmux** | System | Terminal multiplexer |
+| **vim / nano** | System | Text editors |
+| **curl / wget** | System | HTTP clients |
+| **htop** | System | Process viewer |
+
+The `coder` user has passwordless `sudo` access, so you can install additional tools as needed:
+
+```bash
+sudo apt-get update && sudo apt-get install -y <package>
+```
+
+Note: Packages installed via `sudo` will not persist across container restarts. To make them permanent, add them to the `Dockerfile`.
+
+## Volume Reference
+
+| Volume | Container Path | Purpose |
+|--------|---------------|---------|
+| `opencode-auth` | `/home/coder/.local/share/opencode` | OpenCode authentication credentials and session data |
+| `opencode-config` | `/home/coder/.config/opencode` | OpenCode configuration (`opencode.json`) |
+| `workspace` | `/home/coder/workspace` | Cloned repositories and project files |
+
+All three volumes are Docker named volumes, which persist data across container restarts, rebuilds, and redeployments.
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SSH_PUBLIC_KEY` | No* | — | SSH public key for key-based auth |
+| `SSH_PASSWORD` | No* | — | Password for SSH password auth |
+| `SSH_PORT` | No | `2222` | Host port mapped to container SSH |
+| `GIT_REPO_URL` | No | — | Repository URL to clone on startup |
+| `GIT_BRANCH` | No | — | Branch to checkout (default: repo default) |
+| `GIT_USER_NAME` | No | — | Git commit author name |
+| `GIT_USER_EMAIL` | No | — | Git commit author email |
+| `OPENCODE_CONFIG_JSON` | No | — | Full opencode config JSON (overrides default) |
+| `ANTHROPIC_API_KEY` | No | — | Anthropic API key |
+| `OPENAI_API_KEY` | No | — | OpenAI API key |
+| `GOOGLE_API_KEY` | No | — | Google Gemini API key |
+| `OPENROUTER_API_KEY` | No | — | OpenRouter API key |
+| `GITHUB_TOKEN` | No | — | GitHub PAT for `gh` CLI |
+
+\* At least one of `SSH_PUBLIC_KEY` or `SSH_PASSWORD` is recommended. If neither is set, a random password is generated and logged.
+
+## Troubleshooting
+
+### Cannot connect via SSH
+
+- Verify the SSH port is exposed: `docker compose ps` should show `0.0.0.0:2222->22/tcp`
+- Check container logs: `docker compose logs opencode`
+- Ensure your firewall allows the SSH port
+- On Dokploy, confirm the port is configured in the Ports settings
+
+### Authentication credentials lost after restart
+
+- Verify the `opencode-auth` volume exists: `docker volume ls | grep opencode-auth`
+- Ensure you're not using `docker compose down -v` (the `-v` flag deletes volumes)
+
+### opencode command not found
+
+- The binary should be at `~/.local/bin/opencode`. Check with: `ls -la ~/.local/bin/`
+- If missing, reinstall: `curl -fsSL https://opencode.ai/install | bash`
+
+### Container exits immediately
+
+- Check logs: `docker compose logs opencode`
+- Common cause: SSH daemon fails to start. Ensure `/run/sshd` exists (it's created in the Dockerfile)
+
+### Git clone fails on startup
+
+- Verify `GIT_REPO_URL` is accessible from the container
+- For private repos, ensure SSH keys or tokens are configured
+- Check logs for specific git error messages
+
+### Dokploy network not found
+
+If you see an error about `dokploy-network`:
+- Running on Dokploy: The network should exist automatically. Try redeploying.
+- Running standalone: Create it manually (`docker network create dokploy-network`) or remove the `networks` section from `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     restart: unless-stopped
     ports:
       - "${SSH_PORT:-2222}:22"
+      - "${OPENCODE_PORT:-4096}:${OPENCODE_PORT:-4096}"
     env_file:
       - .env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  opencode:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "${SSH_PORT:-2222}:22"
+    env_file:
+      - .env
+    volumes:
+      - opencode-auth:/home/coder/.local/share/opencode
+      - opencode-config:/home/coder/.config/opencode
+      - workspace:/home/coder/workspace
+    networks:
+      - dokploy-network
+
+volumes:
+  opencode-auth:
+  opencode-config:
+  workspace:
+
+networks:
+  dokploy-network:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,16 +9,14 @@ services:
     env_file:
       - .env
     volumes:
-      - opencode-auth:/home/coder/.local/share/opencode
-      - opencode-config:/home/coder/.config/opencode
-      - workspace:/home/coder/workspace
+      - coder-home:/home/coder
+      - ssh-host-keys:/etc/ssh/host_keys
     networks:
       - dokploy-network
 
 volumes:
-  opencode-auth:
-  opencode-config:
-  workspace:
+  coder-home:
+  ssh-host-keys:
 
 networks:
   dokploy-network:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,6 +89,28 @@ if [ -n "$OPENCODE_CONFIG_JSON" ]; then
     echo "OpenCode config overridden from OPENCODE_CONFIG_JSON env var."
 fi
 
+# --- Gitea MCP Server ---
+if [ -n "$GITEA_URL" ] && [ -n "$GITEA_TOKEN" ]; then
+    GITEA_MCP_CONFIG=$(jq -n \
+        --arg host "$GITEA_URL" \
+        --arg token "$GITEA_TOKEN" \
+        '{
+            "type": "local",
+            "command": ["gitea-mcp", "-t", "stdio"],
+            "enabled": true,
+            "environment": {
+                "GITEA_HOST": $host,
+                "GITEA_ACCESS_TOKEN": $token
+            }
+        }')
+
+    jq --argjson gitea "$GITEA_MCP_CONFIG" '.mcp.gitea = $gitea' \
+        "$OPENCODE_CONFIG_FILE" > "${OPENCODE_CONFIG_FILE}.tmp" \
+        && mv "${OPENCODE_CONFIG_FILE}.tmp" "$OPENCODE_CONFIG_FILE"
+    chown coder:coder "$OPENCODE_CONFIG_FILE"
+    echo "Gitea MCP server configured for $GITEA_URL."
+fi
+
 # Ensure directories exist and are owned by coder
 mkdir -p /home/coder/.local/share/opencode
 chown -R coder:coder /home/coder/.local/share/opencode
@@ -118,6 +140,25 @@ if [ -n "$GIT_USER_EMAIL" ]; then
     su - coder -c "git config --global user.email '$GIT_USER_EMAIL'"
 fi
 
-# --- Start SSH Daemon ---
-echo "Starting SSH server on port 22..."
-exec /usr/sbin/sshd -D -e
+# --- Start Services ---
+OPENCODE_MODE="${OPENCODE_MODE:-ssh}"
+OPENCODE_PORT="${OPENCODE_PORT:-4096}"
+
+case "$OPENCODE_MODE" in
+    web)
+        echo "Starting SSH server in background..."
+        /usr/sbin/sshd -e
+        echo "Starting opencode web UI on port $OPENCODE_PORT..."
+        exec su - coder -c "opencode web --port $OPENCODE_PORT --hostname 0.0.0.0"
+        ;;
+    serve)
+        echo "Starting SSH server in background..."
+        /usr/sbin/sshd -e
+        echo "Starting opencode server on port $OPENCODE_PORT..."
+        exec su - coder -c "opencode serve --port $OPENCODE_PORT --hostname 0.0.0.0"
+        ;;
+    ssh|*)
+        echo "Starting SSH server on port 22..."
+        exec /usr/sbin/sshd -D -e
+        ;;
+esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,45 @@
 #!/bin/bash
 set -e
 
+# --- First-boot Home Directory Initialization ---
+if [ ! -f /home/coder/.initialized ]; then
+    cp -rn /etc/skel.coder/. /home/coder/
+    touch /home/coder/.initialized
+    chown -R coder:coder /home/coder
+    echo "Initialized home directory from skeleton."
+fi
+
+# --- Timezone ---
+if [ -n "$TZ" ]; then
+    ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
+    echo "$TZ" > /etc/timezone
+    echo "Timezone set to $TZ."
+fi
+
+# --- SSH Host Key Persistence ---
+HOST_KEY_DIR="/etc/ssh/host_keys"
+mkdir -p "$HOST_KEY_DIR"
+
+if [ -f "$HOST_KEY_DIR/ssh_host_ed25519_key" ]; then
+    cp "$HOST_KEY_DIR"/ssh_host_* /etc/ssh/
+    echo "Restored persisted SSH host keys."
+else
+    ssh-keygen -A
+    cp /etc/ssh/ssh_host_* "$HOST_KEY_DIR/"
+    echo "Generated and persisted new SSH host keys."
+fi
+
 # --- SSH Configuration ---
 sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
 sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
-sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+
+# Smart password auth: disable when key is provided without password
+if [ -n "$SSH_PUBLIC_KEY" ] && [ -z "$SSH_PASSWORD" ]; then
+    sed -i 's/#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+    echo "Password authentication disabled (key-only mode)."
+else
+    sed -i 's/#\?PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+fi
 
 # SSH public key auth
 if [ -n "$SSH_PUBLIC_KEY" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+# --- SSH Configuration ---
+sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+
+# SSH public key auth
+if [ -n "$SSH_PUBLIC_KEY" ]; then
+    mkdir -p /home/coder/.ssh
+    echo "$SSH_PUBLIC_KEY" > /home/coder/.ssh/authorized_keys
+    chmod 700 /home/coder/.ssh
+    chmod 600 /home/coder/.ssh/authorized_keys
+    chown -R coder:coder /home/coder/.ssh
+    echo "SSH public key configured."
+fi
+
+# SSH password auth
+if [ -n "$SSH_PASSWORD" ]; then
+    echo "coder:$SSH_PASSWORD" | chpasswd
+    echo "SSH password configured for user 'coder'."
+else
+    if [ -z "$SSH_PUBLIC_KEY" ]; then
+        GENERATED_PW=$(openssl rand -base64 16)
+        echo "coder:$GENERATED_PW" | chpasswd
+        echo "WARNING: No SSH_PUBLIC_KEY or SSH_PASSWORD set."
+        echo "Generated password for 'coder': $GENERATED_PW"
+    fi
+fi
+
+# --- OpenCode Config ---
+OPENCODE_CONFIG_DIR="/home/coder/.config/opencode"
+OPENCODE_CONFIG_FILE="${OPENCODE_CONFIG_DIR}/opencode.json"
+
+if [ ! -f "$OPENCODE_CONFIG_FILE" ]; then
+    mkdir -p "$OPENCODE_CONFIG_DIR"
+    cat > "$OPENCODE_CONFIG_FILE" <<'EOCFG'
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "*": "allow"
+  }
+}
+EOCFG
+    chown -R coder:coder "$OPENCODE_CONFIG_DIR"
+    echo "Default opencode config created with full permissions."
+fi
+
+# Override config from env var if provided
+if [ -n "$OPENCODE_CONFIG_JSON" ]; then
+    echo "$OPENCODE_CONFIG_JSON" > "$OPENCODE_CONFIG_FILE"
+    chown coder:coder "$OPENCODE_CONFIG_FILE"
+    echo "OpenCode config overridden from OPENCODE_CONFIG_JSON env var."
+fi
+
+# Ensure directories exist and are owned by coder
+mkdir -p /home/coder/.local/share/opencode
+chown -R coder:coder /home/coder/.local/share/opencode
+chown -R coder:coder /home/coder/.config
+
+# --- Git Repo Cloning ---
+if [ -n "$GIT_REPO_URL" ]; then
+    CLONE_DIR="/home/coder/workspace/$(basename "$GIT_REPO_URL" .git)"
+    if [ ! -d "$CLONE_DIR" ]; then
+        BRANCH_FLAG=""
+        if [ -n "$GIT_BRANCH" ]; then
+            BRANCH_FLAG="--branch $GIT_BRANCH"
+        fi
+        echo "Cloning $GIT_REPO_URL into $CLONE_DIR..."
+        su - coder -c "git clone $BRANCH_FLAG '$GIT_REPO_URL' '$CLONE_DIR'"
+        echo "Repository cloned successfully."
+    else
+        echo "Repository already exists at $CLONE_DIR, skipping clone."
+    fi
+fi
+
+# --- Git Config ---
+if [ -n "$GIT_USER_NAME" ]; then
+    su - coder -c "git config --global user.name '$GIT_USER_NAME'"
+fi
+if [ -n "$GIT_USER_EMAIL" ]; then
+    su - coder -c "git config --global user.email '$GIT_USER_EMAIL'"
+fi
+
+# --- Start SSH Daemon ---
+echo "Starting SSH server on port 22..."
+exec /usr/sbin/sshd -D -e


### PR DESCRIPTION
Docker container setup running opencode (AI coding agent) accessible via SSH, web browser, or remote TUI client, designed for 24/7 deployment on Dokploy or any Docker host
	∙	Three access modes (OPENCODE_MODE): ssh (default), web (browser UI on port 4096), serve (headless API for opencode attach remote clients)
	∙	Official Gitea MCP server pre-installed — set GITEA_URL + GITEA_TOKEN to give the AI agent full Gitea access (repos, issues, PRs, branches, releases)
	∙	Full home directory persistence via single coder-home volume
	∙	SSH host key persistence, multi-arch support, smart SSH auth, HEALTHCHECK, timezone support