### PR TITLE
Remove ubuntu user before creating coder user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN go install gitea.com/gitea/gitea-mcp@latest \
     && rm -rf "${GOPATH}"
 
 # Create non-root user
-RUN useradd -m -s /bin/bash -u 1000 coder \
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd -m -s /bin/bash -u 1000 coder \
     && echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/coder \
     && chmod 0440 /etc/sudoers.d/coder
 


### PR DESCRIPTION
## Summary
Updated the Dockerfile to remove the pre-existing `ubuntu` user before creating the `coder` non-root user, ensuring a clean user setup without conflicts.

## Key Changes
- Added `userdel -r ubuntu 2>/dev/null || true` command to remove the ubuntu user if it exists
- The command safely handles cases where the ubuntu user may not be present (suppresses errors and continues)
- Maintains the existing coder user creation with UID 1000 and sudo privileges

## Implementation Details
- Uses `userdel -r` to recursively remove the user and associated files
- Error output is redirected to `/dev/null` with `|| true` fallback to prevent build failures if the user doesn't exist
- This ensures the coder user can be created with UID 1000 without potential conflicts from the default ubuntu user that may exist in the base image

https://claude.ai/code/session_015aAW7bRDpa8vds2CxbGagc