### PR TITLE
Remove ubuntu user before creating coder user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN go install gitea.com/gitea/gitea-mcp@latest \
     && rm -rf "${GOPATH}"
 
 # Create non-root user
-RUN useradd -m -s /bin/bash -u 1000 coder \
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd -m -s /bin/bash -u 1000 coder \
     && echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/coder \
     && chmod 0440 /etc/sudoers.d/coder
 


### PR DESCRIPTION
## Summary
Updated the Dockerfile to remove the pre-existing `ubuntu` user before creating the `coder` non-root user, ensuring a clean user setup without conflicts.

## Key Changes
- Added `userdel -r ubuntu 2>/dev/null || true` command to remove the ubuntu user if it exists
- This prevents potential UID conflicts and ensures the coder user is created cleanly with UID 1000
- The command safely handles cases where the ubuntu user may not exist (suppresses errors with `|| true`)

## Implementation Details
- The `userdel -r` flag recursively removes the user and their home directory
- Error output is redirected to `/dev/null` to avoid noise in the build logs
- The `|| true` ensures the build continues even if the ubuntu user doesn't exist, making the Dockerfile more portable across different base images

https://claude.ai/code/session_01BkRVQ4V486ND9svC8UGhWM