### PR TITLE
Fix ARM64 Go binary download architecture mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:24.04
 
-ARG TARGETARCH=amd64
-
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
@@ -33,7 +31,8 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 # Go 1.26.x (multi-arch)
-RUN curl -fsSL "https://go.dev/dl/go1.26.1.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -fsSL "https://go.dev/dl/go1.26.1.linux-${ARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Install Gitea MCP server (official Go binary)


### PR DESCRIPTION
## Summary
- Replace `ARG TARGETARCH=amd64` with runtime `dpkg --print-architecture` for Go download URL
- Fixes ARM64 builds on Dokploy (Raspberry Pi 4) which don't use `docker buildx --platform`, causing the build arg to default to `amd64` and downloading the wrong Go binary

## Test plan
- [x] All 33 bats unit tests pass
- [ ] Verify Docker build succeeds on Dokploy (ARM64)
- [ ] Verify Docker build still succeeds on Coolify (AMD64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)