### PR TITLE
Remove env_file directive from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     ports:
       - "${SSH_PORT:-2222}:22"
       - "${OPENCODE_PORT:-4096}:${OPENCODE_PORT:-4096}"
-    env_file:
-      - .env
     volumes:
       - coder-home:/home/coder
       - ssh-host-keys:/etc/ssh/host_keys


### PR DESCRIPTION
## Summary
- Remove `env_file: .env` from docker-compose.yml
- Dokploy injects environment variables directly via its UI, making the `.env` file reference unnecessary and causing build failures

## Test plan
- [ ] Verify Dokploy deploys successfully without the env_file directive
- [ ] Confirm environment variables are still injected correctly via Dokploy UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)