### PR TITLE
Make serve the default mode, SSH optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,17 @@
-# SSH Access Configuration
+# OpenCode Access Mode
+OPENCODE_MODE=serve          # Access mode: serve, web, or ssh (default: serve)
+OPENCODE_PORT=4096           # Port for web/serve modes (default: 4096)
+OPENCODE_AUTO_UPDATE=false   # Set to true to check for OpenCode updates on container start
+OPENCODE_SERVER_PASSWORD=    # HTTP Basic Auth password for web/serve modes
+OPENCODE_SERVER_USERNAME=    # HTTP Basic Auth username (default: opencode)
+
+# SSH Access (optional — only used when OPENCODE_MODE=ssh or SSH_ENABLED=true)
+SSH_ENABLED=false            # Start SSH in background for serve/web modes (default: false)
 SSH_PUBLIC_KEY=              # Your SSH public key (contents of ~/.ssh/id_ed25519.pub)
 SSH_PASSWORD=                # Fallback password for SSH (if no key provided)
-SSH_PORT=2222                # Host port mapped to container SSH (default: 2222)
 
 # System Configuration
 TZ=                          # Timezone (e.g., America/New_York, Europe/London, Asia/Tokyo)
-
-# OpenCode Access Mode
-OPENCODE_MODE=ssh            # Access mode: ssh, web, or serve (default: ssh)
-OPENCODE_PORT=4096           # Port for web/serve modes (default: 4096)
-OPENCODE_SERVER_PASSWORD=    # HTTP Basic Auth password for web/serve modes
-OPENCODE_SERVER_USERNAME=    # HTTP Basic Auth username (default: opencode)
 
 # Git Configuration
 GIT_REPO_URL=                # Repository to clone on startup (e.g., https://github.com/user/repo.git)
@@ -19,7 +20,6 @@ GIT_USER_NAME=               # Git user.name for commits
 GIT_USER_EMAIL=              # Git user.email for commits
 
 # OpenCode Configuration
-OPENCODE_AUTO_UPDATE=false   # Set to true to check for OpenCode updates on container start
 OPENCODE_CONFIG_JSON=        # Full opencode.json contents (overrides default config)
 
 # AI Provider API Keys (optional - set these if not using OpenCode Go)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,15 @@
 
 ## Project Overview
 
-Docker container packaging the [OpenCode](https://opencode.ai) AI coding agent for deployment on [Dokploy](https://dokploy.com) or any Docker host. Provides SSH, web, and serve access modes.
+Docker container packaging the [OpenCode](https://opencode.ai) AI coding agent for deployment on [Dokploy](https://dokploy.com) or any Docker host. Default mode is `serve` (HTTP API). SSH is optional via `SSH_ENABLED=true` or `OPENCODE_MODE=ssh`.
 
 ## Key Files
 
-- `entrypoint.sh` — Main initialization script. Validates env vars, configures SSH, sets up OpenCode config, handles auto-update, clones repos, and starts services.
+- `entrypoint.sh` — Main initialization script. Validates env vars, conditionally configures SSH, sets up OpenCode config, handles auto-update, clones repos, and starts services.
+- `healthcheck.sh` — Mode-aware Docker healthcheck (HTTP for serve/web, ssh-keyscan for ssh mode).
 - `Dockerfile` — Multi-arch Ubuntu 24.04 image with Node.js 22, Go 1.26, Python 3, GitHub CLI, and Gitea MCP.
 - `docker-compose.yml` — Compose config with named volumes (`coder-home`, `ssh-host-keys`) and `dokploy-network`.
-- `.env.example` — All 20 configurable environment variables with descriptions.
+- `.env.example` — All 21 configurable environment variables with descriptions.
 
 ## Architecture
 
@@ -19,7 +20,7 @@ The container runs as a non-root `coder` user (UID 1000) with passwordless sudo.
 
 1. Validate environment variables (fails fast on errors)
 2. Initialize home directory from skeleton (first boot only)
-3. Configure timezone, SSH host keys, SSH auth
+3. Configure timezone, SSH (only if `OPENCODE_MODE=ssh` or `SSH_ENABLED=true`)
 4. Auto-update OpenCode binary (if `OPENCODE_AUTO_UPDATE=true`)
 5. Generate/override OpenCode config, configure Gitea MCP
 6. Clone git repo (if `GIT_REPO_URL` set)
@@ -44,7 +45,7 @@ Tests use [bats-core](https://github.com/bats-core/bats-core) (auto-installed by
 
 - `tests/test_helper.bash` — Sources entrypoint functions via the testing guard
 - `tests/test_logging.bats` — 6 tests for `log_info`, `log_warn`, `log_error`
-- `tests/test_validate_env.bats` — 27 tests covering all validation paths
+- `tests/test_validate_env.bats` — 33 tests covering all validation paths
 
 ## Shell Script Conventions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,11 +70,12 @@ RUN mkdir -p /etc/skel.coder/.config/opencode \
     && cp -a /home/coder/.profile /etc/skel.coder/.profile 2>/dev/null || true
 
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY healthcheck.sh /healthcheck.sh
+RUN chmod +x /entrypoint.sh /healthcheck.sh
 
-EXPOSE 22 4096
+EXPOSE 4096
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD ssh-keyscan -p 22 localhost >/dev/null 2>&1 || exit 1
+    CMD /healthcheck.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install-bats:
 
 # Static analysis with shellcheck
 lint:
-	$(SHELLCHECK) -s bash entrypoint.sh
+	$(SHELLCHECK) -s bash entrypoint.sh healthcheck.sh
 
 # Unit tests (no Docker required)
 test-unit: install-bats

--- a/README.md
+++ b/README.md
@@ -1,39 +1,49 @@
 # OpenCode Docker Container for Dokploy
 
-A Docker container running [opencode](https://opencode.ai) — an open-source AI coding agent with a terminal UI — accessible via SSH, web browser, or remote TUI client. Designed for 24/7 deployment on [Dokploy](https://dokploy.com) (self-hosted PaaS) or any Docker host.
+A Docker container running [opencode](https://opencode.ai) — an open-source AI coding agent with a terminal UI — accessible via browser, remote TUI client, or SSH. Designed for 24/7 deployment on [Dokploy](https://dokploy.com) (self-hosted PaaS) or any Docker host.
 
 ## Quick Start
+
+For Dokploy deployment, see [Dokploy Deployment](#dokploy-deployment).
+
+For standalone Docker usage:
 
 ```bash
 # 1. Clone this repo
 git clone https://github.com/Du7chManiac/agent-container.git
 cd agent-container
 
-# 2. Configure environment
-cp .env.example .env
-# Edit .env — at minimum set SSH_PUBLIC_KEY or SSH_PASSWORD
+# 2. Create the external network
+docker network create dokploy-network
 
 # 3. Start the container
 docker compose up -d
 
-# 4. SSH into the container
-ssh coder@localhost -p 2222
-
-# 5. Launch opencode
-opencode
+# 4. Access via browser or remote TUI
+# Browser (web mode): http://localhost:4096
+# Remote TUI (serve mode): opencode attach http://localhost:4096
 ```
+
+> **Note:** When running standalone, you may need to add `ports` back to `docker-compose.yml` or use `docker exec` to access the container. See `env.example` for all configurable environment variables.
 
 ## Access Modes
 
 The container supports three access modes, controlled by the `OPENCODE_MODE` environment variable:
 
-### SSH Mode (default)
+### Serve Mode (default)
 
 ```bash
-OPENCODE_MODE=ssh
+OPENCODE_MODE=serve
 ```
 
-Traditional SSH access. Connect via SSH and run `opencode` interactively in your terminal. SSH is always available in all modes.
+Starts a headless HTTP API server (REST + SSE). This allows:
+
+- **Remote TUI** — Connect a local opencode terminal client to the remote server:
+  ```bash
+  opencode attach https://your-domain.example.com
+  ```
+- **Multiple clients** — Several browsers or TUI clients can connect simultaneously to the same server, sharing session state
+- **API access** — Full REST API with OpenAPI 3.1 spec available at `/doc`
 
 ### Web Mode
 
@@ -44,27 +54,18 @@ OPENCODE_MODE=web
 Starts the opencode web UI — a full browser-based interface for interacting with the AI agent. Access it at:
 
 ```
-http://your-server-ip:4096
+https://your-domain.example.com
 ```
 
-SSH remains available in the background for troubleshooting.
-
-### Serve Mode
+### SSH Mode (advanced)
 
 ```bash
-OPENCODE_MODE=serve
+OPENCODE_MODE=ssh
 ```
 
-Starts a headless HTTP API server (REST + SSE). This allows:
+Traditional SSH access. Connect via SSH and run `opencode` interactively in your terminal. This mode is useful for troubleshooting or when you prefer a direct terminal connection.
 
-- **Remote TUI** — Connect a local opencode terminal client to the remote server:
-  ```bash
-  opencode attach http://your-server-ip:4096
-  ```
-- **Multiple clients** — Several browsers or TUI clients can connect simultaneously to the same server, sharing session state
-- **API access** — Full REST API with OpenAPI 3.1 spec available at `/doc`
-
-SSH remains available in the background.
+> **Tip:** You can also enable SSH alongside serve/web modes by setting `SSH_ENABLED=true`. See [Optional SSH Access](#optional-ssh-access-advanced).
 
 ### Authentication for Web/Serve Modes
 
@@ -94,29 +95,37 @@ OPENCODE_PORT=8080
    - Create a new **Compose** project
    - Point it to this repository (or paste the `docker-compose.yml` contents)
 
-2. **Set environment variables** in Dokploy's Environment tab:
-   - `SSH_PUBLIC_KEY` — your public key for SSH access
-   - `SSH_PORT` — the host port for SSH (default: `2222`)
-   - `OPENCODE_MODE` — set to `web` or `serve` for browser/remote access
+2. **Set environment variables** in Dokploy's **Environment** tab:
+   - `OPENCODE_SERVER_PASSWORD` — secure your web/serve endpoint
    - Any API keys you need (see [Environment Variables](#environment-variables))
+   - For `OPENCODE_CONFIG_JSON`, paste the JSON as a single line
 
-3. **Expose ports**:
-   - SSH port (default `2222`) — TCP port, cannot go through Traefik
-   - OpenCode port (default `4096`) — HTTP port, can be proxied through Traefik for web/serve modes
+3. **Configure domain** — In Dokploy's **Domains** settings:
+   - Add a domain (e.g., `opencode.maurissen.xyz`)
+   - Set the container port to `4096` (or your custom `OPENCODE_PORT`)
+   - Traefik handles SSL termination and HTTP routing automatically
 
 4. **Deploy** the service
 
 5. **Connect**:
    ```bash
-   # SSH
-   ssh coder@your-server-ip -p 2222
-
    # Browser (web mode)
-   open http://your-server-ip:4096
+   https://opencode.maurissen.xyz
 
-   # Remote TUI (serve mode)
-   opencode attach http://your-server-ip:4096
+   # Remote TUI (serve mode — default)
+   opencode attach https://opencode.maurissen.xyz
    ```
+
+### Optional: Enable SSH Access
+
+If you need SSH for troubleshooting:
+
+1. Set `SSH_ENABLED=true` in Dokploy's **Environment** tab
+2. Set `SSH_PUBLIC_KEY` or `SSH_PASSWORD`
+3. In Dokploy's **Ports** settings, add a TCP port mapping:
+   - Host port: `2222` (or any available port)
+   - Container port: `22`
+4. Connect: `ssh coder@your-server-ip -p 2222`
 
 ### Network Note
 
@@ -128,12 +137,9 @@ The `docker-compose.yml` references `dokploy-network` as an external network. Th
 
 [OpenCode Go](https://opencode.ai) ($10/month) provides access to multiple AI models without needing individual API keys.
 
-1. SSH into the container:
-   ```bash
-   ssh coder@your-server -p 2222
-   ```
+1. Access the container (via web UI, remote TUI, or SSH)
 
-2. Start opencode:
+2. Start opencode (if using SSH):
    ```bash
    opencode
    ```
@@ -159,11 +165,16 @@ GOOGLE_API_KEY=AI...
 
 These are passed into the container and opencode will detect them automatically.
 
-## SSH Access
+## Optional SSH Access (Advanced)
+
+SSH is disabled by default. Enable it with one of:
+
+- **SSH-only mode**: `OPENCODE_MODE=ssh` — SSH as the foreground process (no web/serve)
+- **SSH alongside serve/web**: `SSH_ENABLED=true` — starts SSH in the background
 
 ### Key-based Authentication (Recommended)
 
-Set `SSH_PUBLIC_KEY` in your `.env` to the contents of your public key:
+Set `SSH_PUBLIC_KEY` to the contents of your public key:
 
 ```bash
 SSH_PUBLIC_KEY="ssh-ed25519 AAAAC3... user@machine"
@@ -178,7 +189,7 @@ ssh coder@your-server -p 2222
 
 ### Password Authentication
 
-Set `SSH_PASSWORD` in your `.env`:
+Set `SSH_PASSWORD`:
 
 ```bash
 SSH_PASSWORD=your-secure-password
@@ -190,7 +201,7 @@ If both `SSH_PUBLIC_KEY` and `SSH_PASSWORD` are set, both authentication methods
 
 ### No Credentials Set
 
-If neither `SSH_PUBLIC_KEY` nor `SSH_PASSWORD` is configured, the entrypoint generates a random password and prints it to the container logs. Check with:
+If SSH is enabled but neither `SSH_PUBLIC_KEY` nor `SSH_PASSWORD` is configured, the entrypoint generates a random password and prints it to the container logs. Check with:
 
 ```bash
 docker compose logs opencode
@@ -211,7 +222,7 @@ The clone is idempotent — if the directory already exists (from a previous run
 
 ### Manual Cloning
 
-SSH in and clone repos into `~/workspace/`:
+Access the container and clone repos into `~/workspace/`:
 
 ```bash
 cd ~/workspace
@@ -287,7 +298,7 @@ OPENCODE_CONFIG_JSON='{"$schema":"https://opencode.ai/config.json","provider":"a
 
 ### Edit Directly
 
-The config file is persisted in the `coder-home` volume. SSH in and edit it:
+The config file is persisted in the `coder-home` volume. Access the container and edit it:
 
 ```bash
 nano ~/.config/opencode/opencode.json
@@ -354,25 +365,29 @@ On first start (when the `coder-home` volume is empty), the entrypoint copies a 
 
 ### Health Check
 
-The container includes a Docker HEALTHCHECK that verifies the SSH daemon is accepting connections. Docker and Dokploy will report the container as `healthy` once SSH is ready, and will flag it as `unhealthy` if the SSH daemon becomes unresponsive.
+The container includes a Docker HEALTHCHECK that adapts to the active mode:
+- **serve/web**: Checks the HTTP endpoint on the configured port
+- **ssh**: Verifies the SSH daemon is accepting connections
+
+Docker and Dokploy will report the container as `healthy` once the primary service is ready.
 
 ## Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `SSH_PUBLIC_KEY` | No* | — | SSH public key for key-based auth |
-| `SSH_PASSWORD` | No* | — | Password for SSH password auth |
-| `SSH_PORT` | No | `2222` | Host port mapped to container SSH |
-| `TZ` | No | `UTC` | Timezone (e.g., `America/New_York`) |
-| `OPENCODE_MODE` | No | `ssh` | Access mode: `ssh`, `web`, or `serve` |
+| `OPENCODE_MODE` | No | `serve` | Access mode: `serve`, `web`, or `ssh` |
 | `OPENCODE_PORT` | No | `4096` | Port for web/serve modes |
+| `OPENCODE_AUTO_UPDATE` | No | `false` | Set to `true` to update OpenCode on startup |
 | `OPENCODE_SERVER_PASSWORD` | No | — | HTTP Basic Auth password for web/serve |
 | `OPENCODE_SERVER_USERNAME` | No | `opencode` | HTTP Basic Auth username for web/serve |
+| `SSH_ENABLED` | No | `false` | Start SSH in background for serve/web modes |
+| `SSH_PUBLIC_KEY` | No | — | SSH public key for key-based auth |
+| `SSH_PASSWORD` | No | — | Password for SSH password auth |
+| `TZ` | No | `UTC` | Timezone (e.g., `America/New_York`) |
 | `GIT_REPO_URL` | No | — | Repository URL to clone on startup |
 | `GIT_BRANCH` | No | — | Branch to checkout (default: repo default) |
 | `GIT_USER_NAME` | No | — | Git commit author name |
 | `GIT_USER_EMAIL` | No | — | Git commit author email |
-| `OPENCODE_AUTO_UPDATE` | No | `false` | Set to `true` to update OpenCode on startup |
 | `OPENCODE_CONFIG_JSON` | No | — | Full opencode config JSON (overrides default) |
 | `ANTHROPIC_API_KEY` | No | — | Anthropic API key |
 | `OPENAI_API_KEY` | No | — | OpenAI API key |
@@ -382,7 +397,7 @@ The container includes a Docker HEALTHCHECK that verifies the SSH daemon is acce
 | `GITEA_URL` | No | — | Gitea instance URL |
 | `GITEA_TOKEN` | No | — | Gitea personal access token |
 
-\* At least one of `SSH_PUBLIC_KEY` or `SSH_PASSWORD` is recommended. If neither is set, a random password is generated and logged. When only `SSH_PUBLIC_KEY` is set, password authentication is disabled automatically.
+SSH credentials (`SSH_PUBLIC_KEY`, `SSH_PASSWORD`) are only relevant when `OPENCODE_MODE=ssh` or `SSH_ENABLED=true`. If SSH is enabled without credentials, a random password is generated and logged. When only `SSH_PUBLIC_KEY` is set, password authentication is disabled automatically.
 
 ## Auto-Update
 
@@ -400,11 +415,12 @@ On startup, the entrypoint validates all configuration before proceeding. Invali
 
 - `OPENCODE_MODE` must be one of `ssh`, `web`, or `serve`
 - `OPENCODE_PORT` must be a number between 1 and 65535
+- `SSH_ENABLED` must be `true` or `false` if set
 - `TZ` must be a valid timezone from the tz database
 - `GITEA_URL` and `GITEA_TOKEN` must both be set or both empty
 - `OPENCODE_CONFIG_JSON` must be valid JSON if set
 - `GIT_REPO_URL` format is checked (warning only)
-- A warning is shown if no SSH authentication method is configured
+- A warning is shown if SSH is enabled but no authentication method is configured
 
 ## Development
 
@@ -435,7 +451,7 @@ make build
 tests/
   test_helper.bash          # Shared setup: sources entrypoint functions
   test_logging.bats         # Tests for log_info, log_warn, log_error
-  test_validate_env.bats    # Tests for all env validation paths (~27 tests)
+  test_validate_env.bats    # Tests for all env validation paths (~33 tests)
 ```
 
 ### CI
@@ -447,25 +463,25 @@ GitHub Actions runs on every push to `main` and on all pull requests:
 
 ## Troubleshooting
 
-### Cannot connect via SSH
+### Web UI / Serve mode not accessible
 
-- Verify the SSH port is exposed: `docker compose ps` should show `0.0.0.0:2222->22/tcp`
+- Verify the container is running: `docker compose ps`
 - Check container logs: `docker compose logs opencode`
-- Ensure your firewall allows the SSH port
-- On Dokploy, confirm the port is configured in the Ports settings
-
-### Web UI not accessible
-
-- Verify `OPENCODE_MODE=web` is set in your `.env`
-- Check the port is exposed: `docker compose ps` should show `0.0.0.0:4096->4096/tcp`
-- Check container logs: `docker compose logs opencode`
-- Ensure your firewall allows port 4096 (or your custom `OPENCODE_PORT`)
+- On Dokploy, confirm a domain is configured pointing to the container's port 4096
+- If auth is enabled, ensure `OPENCODE_SERVER_PASSWORD` is set correctly
 
 ### Cannot attach remote TUI
 
-- Verify `OPENCODE_MODE=serve` is set
-- Ensure the port is reachable from your local machine
+- The default mode is `serve` — verify the container is running
+- Ensure the port/domain is reachable from your local machine
 - If auth is enabled, set `OPENCODE_SERVER_PASSWORD` on your local machine before running `opencode attach`
+
+### Cannot connect via SSH
+
+- SSH is disabled by default. Ensure `OPENCODE_MODE=ssh` or `SSH_ENABLED=true` is set
+- On Dokploy, confirm a TCP port mapping (e.g., 2222 → 22) is configured in the Ports settings
+- Check container logs: `docker compose logs opencode`
+- Ensure your firewall allows the SSH port
 
 ### "Host key changed" warning after rebuild
 
@@ -491,7 +507,7 @@ ssh-keygen -R "[localhost]:2222"
 ### Container exits immediately
 
 - Check logs: `docker compose logs opencode`
-- Common cause: SSH daemon fails to start. Ensure `/run/sshd` exists (it's created in the Dockerfile)
+- Common cause: opencode binary missing or corrupt. Try setting `OPENCODE_AUTO_UPDATE=true`
 
 ### Git clone fails on startup
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,8 +78,24 @@ validate_env() {
         fi
     fi
 
-    # Warn if no auth method configured
-    if [ -z "${SSH_PUBLIC_KEY:-}" ] && [ -z "${SSH_PASSWORD:-}" ]; then
+    # Validate SSH_ENABLED if set
+    if [ -n "${SSH_ENABLED:-}" ]; then
+        case "$SSH_ENABLED" in
+            true|false) ;;
+            *)
+                log_error "Invalid SSH_ENABLED='$SSH_ENABLED'. Must be 'true' or 'false'"
+                errors=$((errors + 1))
+                ;;
+        esac
+    fi
+
+    # Warn if no auth method configured (only when SSH is active)
+    local ssh_needed=false
+    local mode="${OPENCODE_MODE:-serve}"
+    if [ "$mode" = "ssh" ] || [ "${SSH_ENABLED:-false}" = "true" ]; then
+        ssh_needed=true
+    fi
+    if [ "$ssh_needed" = "true" ] && [ -z "${SSH_PUBLIC_KEY:-}" ] && [ -z "${SSH_PASSWORD:-}" ]; then
         log_warn "No SSH_PUBLIC_KEY or SSH_PASSWORD set. A random password will be generated."
     fi
 
@@ -119,53 +135,65 @@ if [ -n "${TZ:-}" ]; then
 fi
 
 # ==============================================================================
-# SSH Host Key Persistence
+# SSH Setup (only when SSH is needed)
 # ==============================================================================
-HOST_KEY_DIR="/etc/ssh/host_keys"
-mkdir -p "$HOST_KEY_DIR"
+OPENCODE_MODE="${OPENCODE_MODE:-serve}"
+SSH_ENABLED="${SSH_ENABLED:-false}"
 
-if [ -f "$HOST_KEY_DIR/ssh_host_ed25519_key" ]; then
-    cp "$HOST_KEY_DIR"/ssh_host_* /etc/ssh/
-    log_info "Restored persisted SSH host keys."
+# Determine if SSH is needed
+SSH_NEEDED=false
+if [ "$OPENCODE_MODE" = "ssh" ] || [ "$SSH_ENABLED" = "true" ]; then
+    SSH_NEEDED=true
+fi
+
+if [ "$SSH_NEEDED" = "true" ]; then
+    # SSH Host Key Persistence
+    HOST_KEY_DIR="/etc/ssh/host_keys"
+    mkdir -p "$HOST_KEY_DIR"
+
+    if [ -f "$HOST_KEY_DIR/ssh_host_ed25519_key" ]; then
+        cp "$HOST_KEY_DIR"/ssh_host_* /etc/ssh/
+        log_info "Restored persisted SSH host keys."
+    else
+        ssh-keygen -A
+        cp /etc/ssh/ssh_host_* "$HOST_KEY_DIR/"
+        log_info "Generated and persisted new SSH host keys."
+    fi
+
+    # SSH Configuration
+    sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+    sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+    # Smart password auth: disable when key is provided without password
+    if [ -n "${SSH_PUBLIC_KEY:-}" ] && [ -z "${SSH_PASSWORD:-}" ]; then
+        sed -i 's/#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+        log_info "Password authentication disabled (key-only mode)."
+    else
+        sed -i 's/#\?PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+    fi
+
+    # SSH public key auth
+    if [ -n "${SSH_PUBLIC_KEY:-}" ]; then
+        mkdir -p /home/coder/.ssh
+        echo "$SSH_PUBLIC_KEY" > /home/coder/.ssh/authorized_keys
+        chmod 700 /home/coder/.ssh
+        chmod 600 /home/coder/.ssh/authorized_keys
+        chown -R coder:coder /home/coder/.ssh
+        log_info "SSH public key configured."
+    fi
+
+    # SSH password auth
+    if [ -n "${SSH_PASSWORD:-}" ]; then
+        echo "coder:$SSH_PASSWORD" | chpasswd
+        log_info "SSH password configured for user 'coder'."
+    elif [ -z "${SSH_PUBLIC_KEY:-}" ]; then
+        GENERATED_PW=$(openssl rand -base64 16)
+        echo "coder:$GENERATED_PW" | chpasswd
+        log_warn "No SSH_PUBLIC_KEY or SSH_PASSWORD set."
+        log_warn "Generated password for 'coder': $GENERATED_PW"
+    fi
 else
-    ssh-keygen -A
-    cp /etc/ssh/ssh_host_* "$HOST_KEY_DIR/"
-    log_info "Generated and persisted new SSH host keys."
-fi
-
-# ==============================================================================
-# SSH Configuration
-# ==============================================================================
-sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
-sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
-
-# Smart password auth: disable when key is provided without password
-if [ -n "${SSH_PUBLIC_KEY:-}" ] && [ -z "${SSH_PASSWORD:-}" ]; then
-    sed -i 's/#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
-    log_info "Password authentication disabled (key-only mode)."
-else
-    sed -i 's/#\?PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
-fi
-
-# SSH public key auth
-if [ -n "${SSH_PUBLIC_KEY:-}" ]; then
-    mkdir -p /home/coder/.ssh
-    echo "$SSH_PUBLIC_KEY" > /home/coder/.ssh/authorized_keys
-    chmod 700 /home/coder/.ssh
-    chmod 600 /home/coder/.ssh/authorized_keys
-    chown -R coder:coder /home/coder/.ssh
-    log_info "SSH public key configured."
-fi
-
-# SSH password auth
-if [ -n "${SSH_PASSWORD:-}" ]; then
-    echo "coder:$SSH_PASSWORD" | chpasswd
-    log_info "SSH password configured for user 'coder'."
-elif [ -z "${SSH_PUBLIC_KEY:-}" ]; then
-    GENERATED_PW=$(openssl rand -base64 16)
-    echo "coder:$GENERATED_PW" | chpasswd
-    log_warn "No SSH_PUBLIC_KEY or SSH_PASSWORD set."
-    log_warn "Generated password for 'coder': $GENERATED_PW"
+    log_info "SSH disabled. Set OPENCODE_MODE=ssh or SSH_ENABLED=true to enable."
 fi
 
 # ==============================================================================
@@ -298,25 +326,28 @@ fi
 # ==============================================================================
 # Start Services
 # ==============================================================================
-OPENCODE_MODE="${OPENCODE_MODE:-ssh}"
 OPENCODE_PORT="${OPENCODE_PORT:-4096}"
 
 case "$OPENCODE_MODE" in
-    web)
-        log_info "Starting SSH server in background..."
-        /usr/sbin/sshd -e
-        SSHD_PID=$!
-        log_info "Starting opencode web UI on port $OPENCODE_PORT..."
-        exec su - coder -c "opencode web --port $OPENCODE_PORT --hostname 0.0.0.0"
-        ;;
     serve)
-        log_info "Starting SSH server in background..."
-        /usr/sbin/sshd -e
-        SSHD_PID=$!
+        if [ "$SSH_ENABLED" = "true" ]; then
+            log_info "Starting SSH server in background..."
+            /usr/sbin/sshd -e
+            SSHD_PID=$!
+        fi
         log_info "Starting opencode server on port $OPENCODE_PORT..."
         exec su - coder -c "opencode serve --port $OPENCODE_PORT --hostname 0.0.0.0"
         ;;
-    ssh|*)
+    web)
+        if [ "$SSH_ENABLED" = "true" ]; then
+            log_info "Starting SSH server in background..."
+            /usr/sbin/sshd -e
+            SSHD_PID=$!
+        fi
+        log_info "Starting opencode web UI on port $OPENCODE_PORT..."
+        exec su - coder -c "opencode web --port $OPENCODE_PORT --hostname 0.0.0.0"
+        ;;
+    ssh)
         log_info "Starting SSH server on port 22..."
         exec /usr/sbin/sshd -D -e
         ;;

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+MODE="${OPENCODE_MODE:-serve}"
+PORT="${OPENCODE_PORT:-4096}"
+
+case "$MODE" in
+    ssh)
+        ssh-keyscan -p 22 localhost >/dev/null 2>&1 || exit 1
+        ;;
+    *)
+        curl -sf "http://localhost:${PORT}/doc" >/dev/null 2>&1 || exit 1
+        ;;
+esac

--- a/tests/test_validate_env.bats
+++ b/tests/test_validate_env.bats
@@ -5,7 +5,7 @@ setup() {
     # Clear all env vars that validate_env checks
     unset OPENCODE_MODE OPENCODE_PORT TZ GIT_REPO_URL
     unset GITEA_URL GITEA_TOKEN OPENCODE_CONFIG_JSON
-    unset SSH_PUBLIC_KEY SSH_PASSWORD
+    unset SSH_PUBLIC_KEY SSH_PASSWORD SSH_ENABLED
 }
 
 teardown() {
@@ -185,16 +185,60 @@ teardown() {
     [[ "$output" == *"not valid JSON"* ]]
 }
 
-# --- SSH auth warning ---
+# --- SSH_ENABLED validation ---
 
-@test "validate_env: warns when no SSH auth configured" {
+@test "validate_env: accepts SSH_ENABLED=true" {
+    export SSH_ENABLED=true
+    run validate_env
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_env: accepts SSH_ENABLED=false" {
+    export SSH_ENABLED=false
+    run validate_env
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_env: accepts unset SSH_ENABLED" {
+    unset SSH_ENABLED
+    run validate_env
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_env: rejects SSH_ENABLED=invalid" {
+    export SSH_ENABLED=invalid
+    run validate_env
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SSH_ENABLED"* ]]
+}
+
+# --- SSH auth warning (only when SSH is active) ---
+
+@test "validate_env: warns when no SSH auth configured and OPENCODE_MODE=ssh" {
+    export OPENCODE_MODE=ssh
     unset SSH_PUBLIC_KEY SSH_PASSWORD
     run validate_env
     [ "$status" -eq 0 ]
     [[ "$output" == *"random password will be generated"* ]]
 }
 
+@test "validate_env: warns when no SSH auth configured and SSH_ENABLED=true" {
+    export SSH_ENABLED=true
+    unset SSH_PUBLIC_KEY SSH_PASSWORD
+    run validate_env
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"random password will be generated"* ]]
+}
+
+@test "validate_env: no SSH warning in default serve mode" {
+    unset OPENCODE_MODE SSH_ENABLED SSH_PUBLIC_KEY SSH_PASSWORD
+    run validate_env
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"random password"* ]]
+}
+
 @test "validate_env: no warning when SSH_PUBLIC_KEY is set" {
+    export OPENCODE_MODE=ssh
     export SSH_PUBLIC_KEY="ssh-ed25519 AAAA..."
     run validate_env
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- Change default `OPENCODE_MODE` from `ssh` to `serve` since primary access is via browser/remote TUI through a Traefik domain
- Add `SSH_ENABLED` env var to optionally start SSH in background for serve/web modes
- Skip SSH setup entirely (host keys, sshd config, auth) when SSH is disabled
- Add mode-aware `healthcheck.sh` (HTTP check for serve/web, ssh-keyscan for ssh)
- Update Dockerfile to only EXPOSE port 4096 (SSH port optional)
- Restructure README for serve-first documentation flow

## Test plan

- [x] All 39 bats unit tests pass (`make test-unit`)
- [x] `docker compose config` validates successfully
- [x] Deploy with no env vars — should start opencode serve on port 4096
- [x] Deploy with `SSH_ENABLED=true` — should start serve + SSH in background
- [x] Deploy with `OPENCODE_MODE=ssh` — should start SSH as foreground (legacy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)