### PR TITLE
fix: env vars not reaching opencode container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,34 @@ services:
     ports:
       - "${SSH_PORT:-2222}:22"
       - "${OPENCODE_PORT:-4096}:${OPENCODE_PORT:-4096}"
+    environment:
+      # Container config
+      - OPENCODE_MODE=${OPENCODE_MODE:-serve}
+      - OPENCODE_PORT=${OPENCODE_PORT:-4096}
+      - OPENCODE_AUTO_UPDATE=${OPENCODE_AUTO_UPDATE:-false}
+      - OPENCODE_CONFIG_JSON=${OPENCODE_CONFIG_JSON:-}
+      - TZ=${TZ:-}
+      # SSH
+      - SSH_ENABLED=${SSH_ENABLED:-false}
+      - SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY:-}
+      - SSH_PASSWORD=${SSH_PASSWORD:-}
+      # Git
+      - GIT_REPO_URL=${GIT_REPO_URL:-}
+      - GIT_BRANCH=${GIT_BRANCH:-}
+      - GIT_USER_NAME=${GIT_USER_NAME:-}
+      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
+      # Gitea MCP
+      - GITEA_URL=${GITEA_URL:-}
+      - GITEA_TOKEN=${GITEA_TOKEN:-}
+      # Server auth
+      - OPENCODE_SERVER_PASSWORD=${OPENCODE_SERVER_PASSWORD:-}
+      # AI provider API keys (forwarded to opencode via /etc/profile.d/)
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
+      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
     volumes:
       - coder-home:/home/coder
       - ssh-host-keys:/etc/ssh/host_keys


### PR DESCRIPTION
## Summary
- Add `environment:` section to `docker-compose.yml` to inject all 21 env vars into the container runtime
- Dokploy env vars were only available for `${VAR}` substitution in compose but were never passed into the container, leaving `/etc/profile.d/opencode-env.sh` empty

## Root Cause
The entrypoint's profile.d mechanism was working correctly but the `env` command found zero matching vars because docker-compose had no `environment:` section — Dokploy sets vars for compose interpolation, not container injection.

## Test plan
- [x] `make test` passes (39/39 tests, shellcheck clean)
- [ ] Deploy and verify container logs show `Forwarded env vars: ANTHROPIC_API_KEY OPENCODE_SERVER_PASSWORD ...`
- [ ] Verify opencode reports "server is secured" (not "unsecured")
- [ ] Verify Gitea MCP connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)