### PR TITLE
Add native dev libraries, global npm tools, and npm timeout config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,29 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Native development libraries for common npm packages
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libsqlite3-dev \
+    libpq-dev \
+    libcairo2-dev \
+    libjpeg-dev \
+    libpango1.0-dev \
+    libgif-dev \
+    librsvg2-dev \
+    libpixman-1-dev \
+    libxml2-dev \
+    libcurl4-openssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Global npm tools and configuration
+RUN npm install -g node-gyp yarn pnpm \
+    && npm cache clean --force \
+    && npm config -g set fetch-timeout 300000 \
+    && npm config -g set fetch-retries 5 \
+    && npm config -g set fetch-retry-mintimeout 15000 \
+    && npm config -g set fetch-retry-maxtimeout 120000
+
 # GitHub CLI
 RUN mkdir -p -m 755 /etc/apt/keyrings \
     && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/README.md
+++ b/README.md
@@ -332,7 +332,12 @@ docker buildx build --platform linux/arm64 -t opencode-agent .
 | **Git** | System | |
 | **GitHub CLI (gh)** | Latest | Authenticate with `GITHUB_TOKEN` env var |
 | **Gitea MCP** | Latest | Official Go binary, auto-configured via env vars |
+| **node-gyp** | Latest | Native addon build tool (global) |
+| **yarn** | Latest | Alternative package manager (global) |
+| **pnpm** | Latest | Fast, disk-efficient package manager (global) |
 | **build-essential** | System | gcc, g++, make |
+| **pkg-config** | System | Library compile/link flag helper |
+| **Native dev libs** | System | libsqlite3, libpq, libcairo2, libjpeg, libpango, libgif, librsvg2, libpixman, libxml2, libcurl |
 | **ripgrep (rg)** | System | Fast file search |
 | **fd-find (fd)** | System | Fast file finder |
 | **jq** | System | JSON processor |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,6 +145,17 @@ if [ ! -x "$OPENCODE_BIN" ]; then
 fi
 
 # ==============================================================================
+# npm Configuration (for volume-mounted homes that predate image changes)
+# ==============================================================================
+if [ ! -f /home/coder/.npm-initialized ]; then
+    su - coder -c "npm config set fetch-timeout 300000"
+    su - coder -c "npm config set fetch-retries 5"
+    touch /home/coder/.npm-initialized
+    chown coder:coder /home/coder/.npm-initialized
+    log_info "npm configuration initialized for container environment."
+fi
+
+# ==============================================================================
 # Timezone
 # ==============================================================================
 if [ -n "${TZ:-}" ]; then


### PR DESCRIPTION
Fix development tooling issues in the container:
- Add native dev libraries (libsqlite3, libpq, libcairo2, libjpeg, libpango,
  libgif, librsvg2, libpixman, libxml2, libcurl) for compiling npm native
  modules like better-sqlite3, pg-native, node-canvas
- Install node-gyp, yarn, and pnpm globally
- Configure npm with 5-minute fetch timeout and 5 retries to prevent
  the 120s timeout that caused corrupted node_modules and missing peer deps
- Add first-boot npm config in entrypoint.sh for volume-mounted homes
- Update README dev tools table

Fixes: npm install timeouts, better-sqlite3 native binding compilation,
vitest/supertest missing peer dependencies

https://claude.ai/code/session_019MyJ4wAyxHabL6R1B2H3sv