### PR TITLE
revert: remove bogus openchamber Basic Auth sed patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,16 +44,8 @@ RUN npm install -g node-gyp yarn pnpm \
     && npm config -g set fetch-retry-maxtimeout 120000
 
 # OpenChamber web UI (optional alternative to opencode's built-in web — enable via OPENCODE_MODE=openchamber)
-# Patches OpenChamber's Basic Auth format from `opencode:<password>` to `:<password>` (empty username)
-# because opencode 1.4+ changed its server auth to only accept empty-username Basic Auth, which
-# breaks OpenChamber <=1.9.4's built-in health check against the spawned opencode subprocess.
-# Remove this patch once upstream ships a fixed release.
-# See: https://github.com/openchamber/openchamber/issues/891
 RUN npm install -g @openchamber/web@1.9.4 \
-    && npm cache clean --force \
-    && sed -i "s|Buffer.from(\`opencode:\${password}\`)|Buffer.from(\`:\${password}\`)|" \
-       /usr/lib/node_modules/@openchamber/web/server/lib/opencode/auth-state-runtime.js \
-    && grep -q 'Buffer.from(`:${password}`)' /usr/lib/node_modules/@openchamber/web/server/lib/opencode/auth-state-runtime.js
+    && npm cache clean --force
 
 # GitHub CLI
 RUN mkdir -p -m 755 /etc/apt/keyrings \

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ Differences from `web` mode:
 
 Under the hood the entrypoint runs `openchamber --port $OPENCODE_PORT --host 0.0.0.0 --foreground`, and the spawned opencode subprocess binds to a private loopback port (`4097` by default, `4098` if you set `OPENCODE_PORT=4097`).
 
-> **Known upstream compatibility patch:** opencode 1.4+ changed its server-side Basic Auth format to require an **empty username** (`Authorization: Basic base64(:password)`), but `@openchamber/web@1.9.4` still sends `Authorization: Basic base64(opencode:password)`. The result is that OpenChamber's internal health check against the spawned opencode subprocess gets 401 forever and reports `"Server started but health check failed (timeout)"`. The Dockerfile applies a small one-line `sed` patch to OpenChamber's `auth-state-runtime.js` to fix the Basic Auth format. Remove this patch once upstream ships a fixed release — there's a `grep -q` build guard so the image build fails loudly if the target string ever changes.
-
 ### SSH Mode (advanced)
 
 ```bash


### PR DESCRIPTION
The sed patch added in 77471af rewrote @openchamber/web@1.9.4's `Buffer.from(\`opencode:${password}\`)` to `Buffer.from(\`:${password}\`)` on the theory that opencode 1.4+ required empty-username Basic Auth. That theory was wrong. opencode's server uses Hono's basicAuth middleware, which does a timing-safe exact compare of both username and password (default username "opencode"). The only header it accepts is literally `opencode:<password>` — the exact format OpenChamber already sends, and always has.

Symptom on rpi4: Providers page reported "Unable to load provider list", container logs showed "Failed to start OpenCode: Server started but health check failed (timeout)", no opencode subprocess running. Root cause was the patch itself: it turned a correct auth header into one opencode rejects with 401, so OpenChamber's subprocess health poll looped until timeout and gave up spawning opencode.

Reproduced inside the running container:
  curl -u opencode:test http://127.0.0.1:4099/global/health → 200
  curl -u :test         http://127.0.0.1:4099/global/health → 401

Removing the sed + grep guard restores openchamber mode to working state. README's "Known upstream compatibility patch" note is removed for the same reason.