### PR TITLE
feat: run gh auth setup-git when GITHUB_TOKEN is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Docker and Dokploy will report the container as `healthy` once the primary servi
 | `GOOGLE_API_KEY` | No | — | Google Gemini API key |
 | `OPENROUTER_API_KEY` | No | — | OpenRouter API key |
 | `GROQ_API_KEY` | No | — | Groq API key |
-| `GITHUB_TOKEN` | No | — | GitHub PAT for `gh` CLI |
+| `GITHUB_TOKEN` | No | — | GitHub PAT for `gh` CLI. When set, the entrypoint also runs `gh auth setup-git` so `git push`/`git fetch` over HTTPS work non-interactively from the terminal. |
 | `GITEA_URL` | No | — | Gitea instance URL |
 | `GITEA_TOKEN` | No | — | Gitea personal access token |
 | `SSH_PORT` | No | `2222` | Host port mapped to container SSH port 22 |
@@ -567,6 +567,16 @@ ssh-keygen -R "[localhost]:2222"
 - Verify `GIT_REPO_URL` is accessible from the container
 - For private repos, ensure SSH keys or tokens are configured
 - Check logs for specific git error messages
+
+### `git push` to GitHub fails with "could not read Username"
+
+If `git push https://github.com/...` inside the terminal dies with `fatal: could not read Username for 'https://github.com': No such device or address`, the container wasn't started with `GITHUB_TOKEN`. Set `GITHUB_TOKEN` to a PAT with `repo` scope — the entrypoint runs `gh auth setup-git` on startup so HTTPS git ops use the token non-interactively. You can verify with:
+
+```bash
+docker exec -u coder <container> git config --global --get-regexp credential
+```
+
+It should list a helper entry for `https://github.com`. This also silences OpenChamber's `Failed to filter active remote branches, returning all` warning in the branches panel.
 
 ### Gitea MCP not working
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -376,6 +376,18 @@ if [ -n "${GIT_USER_EMAIL:-}" ]; then
     su - coder -c "git config --global user.email '$GIT_USER_EMAIL'"
 fi
 
+# When GITHUB_TOKEN is set, wire gh as git's credential helper for github.com
+# so HTTPS push/fetch work non-interactively inside the terminal. Without
+# this git hits the no-TTY credential prompt and fails with
+# "could not read Username for 'https://github.com'".
+if [ -n "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
+    if su - coder -c "GITHUB_TOKEN=$(printf %q "$GITHUB_TOKEN") gh auth setup-git" >/dev/null 2>&1; then
+        log_info "Configured gh as git credential helper for github.com (GITHUB_TOKEN)."
+    else
+        log_warn "gh auth setup-git failed — git push over HTTPS may prompt for credentials."
+    fi
+fi
+
 # ==============================================================================
 # Start Services
 # ==============================================================================


### PR DESCRIPTION
## Summary
- Wire `gh` as git's credential helper on container startup when `GITHUB_TOKEN` is set, so `git push`/`git fetch` over HTTPS work non-interactively from inside the terminal (OpenChamber, serve, web, ssh modes).
- Without this, git inside the container hit the no-TTY credential prompt and died with `fatal: could not read Username for 'https://github.com': No such device or address`. OpenChamber's branches panel logged the same root cause as `Failed to filter active remote branches, returning all: …`.
- README: updated the `GITHUB_TOKEN` env row and added a troubleshooting entry documenting the verification command (`git config --global --get-regexp credential`).

## Why now
Observed on the Rock 5T deployment — `gh` was already authenticated via `GITHUB_TOKEN` (confirmed with `gh auth status`), but `gh auth setup-git` had never been run, so git had no way to surface the token. One-line fix on startup, no new env vars, no Dockerfile change (gh was already installed).

## Test plan
- [x] `make lint` (shellcheck) passes
- [x] `make test-unit` — all 51 bats tests pass
- [x] `docker compose config` parses
- [ ] After rebuild/redeploy on Rock 5T: `docker exec -u coder <container> git config --global --get-regexp credential` shows a helper entry for `https://github.com`
- [ ] From the OpenChamber terminal, `git push` against a private repo succeeds (with a PAT that has `repo` scope)
- [ ] OpenChamber's branches panel stops logging `Failed to filter active remote branches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)