### PR TITLE
feat: replace gitea-mcp with tea CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,6 @@ OPENROUTER_API_KEY=          # OpenRouter API key
 # GitHub CLI (optional)
 GITHUB_TOKEN=                # GitHub personal access token for gh CLI
 
-# Gitea Integration (optional)
+# Gitea CLI (optional — configures `tea` CLI non-interactively on startup)
 GITEA_URL=                   # Gitea instance URL (e.g., https://gitea.example.com)
-GITEA_TOKEN=                 # Gitea personal access token
+GITEA_TOKEN=                 # Gitea personal access token for the `tea` CLI

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,6 @@ RUN npm install -g node-gyp yarn pnpm \
     && npm config -g set fetch-retry-mintimeout 15000 \
     && npm config -g set fetch-retry-maxtimeout 120000
 
-# OpenChamber web UI (optional alternative to opencode's built-in web — enable via OPENCODE_MODE=openchamber)
-RUN npm install -g @openchamber/web@1.9.4 \
-    && npm cache clean --force
-
 # GitHub CLI
 RUN mkdir -p -m 755 /etc/apt/keyrings \
     && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -96,6 +92,16 @@ RUN mkdir -p /etc/skel.coder/.config/opencode \
     && cp -a /home/coder/.opencode/bin/opencode /etc/skel.coder/.opencode/bin/opencode
 RUN cp -a /home/coder/.bashrc /etc/skel.coder/.bashrc 2>/dev/null || true \
     && cp -a /home/coder/.profile /etc/skel.coder/.profile 2>/dev/null || true
+
+# OpenChamber web UI (optional alternative to opencode's built-in web — enable via OPENCODE_MODE=openchamber).
+# Installed near the bottom of the Dockerfile and gated on CACHEBUST so a redeploy
+# can pull the latest @openchamber/web release without busting the heavier layers
+# above (apt, Node, Go, gh, tea, opencode). Pass --build-arg CACHEBUST=$(date +%s)
+# (or a commit SHA) to force a fresh fetch; otherwise the layer is cached normally.
+ARG CACHEBUST=0
+RUN echo "cachebust=${CACHEBUST}" >/dev/null \
+    && npm install -g @openchamber/web@latest \
+    && npm cache clean --force
 
 COPY entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,11 +62,12 @@ RUN ARCH=$(dpkg --print-architecture) && \
     curl -fsSL "https://go.dev/dl/go1.26.1.linux-${ARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-# Install Gitea MCP server (official Go binary)
-ENV GOPATH="/tmp/go-build"
-RUN go install gitea.com/gitea/gitea-mcp@latest \
-    && cp "${GOPATH}/bin/gitea-mcp" /usr/local/bin/gitea-mcp \
-    && rm -rf "${GOPATH}"
+# Gitea tea CLI (multi-arch prebuilt binary)
+ARG TEA_VERSION=0.11.0
+RUN ARCH=$(dpkg --print-architecture) \
+    && curl -fsSL "https://dl.gitea.com/tea/${TEA_VERSION}/tea-${TEA_VERSION}-linux-${ARCH}" \
+         -o /usr/local/bin/tea \
+    && chmod +x /usr/local/bin/tea
 
 # Create non-root user
 RUN userdel -r ubuntu 2>/dev/null || true \

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ GIT_USER_EMAIL="you@example.com"
 
 ## Gitea Integration
 
-The container includes the [official Gitea MCP server](https://gitea.com/gitea/gitea-mcp), pre-installed as a Go binary. When configured, this gives the AI agent direct access to your Gitea instance — it can manage repositories, issues, pull requests, branches, releases, and more.
+The container ships the [official Gitea `tea` CLI](https://gitea.com/gitea/tea) — Gitea's counterpart to the GitHub `gh` CLI. When configured, the agent (or you, over SSH) can drive repositories, issues, pull requests, releases, and more from the shell.
 
 ### Setup
 
@@ -281,7 +281,9 @@ GITEA_URL=https://gitea.example.com    # Your Gitea instance URL
 GITEA_TOKEN=your-personal-access-token  # Gitea PAT with appropriate scopes
 ```
 
-On startup, the entrypoint automatically injects the Gitea MCP server configuration into `opencode.json`. The AI agent will have access to Gitea tools in its next session.
+On startup the entrypoint runs `tea login add --name default --url $GITEA_URL --token $GITEA_TOKEN` as the `coder` user, writing persistent auth to `~/.config/tea/config.yml`. The existing `default` login is deleted first so rotating the token and restarting the container just works.
+
+Both vars are also forwarded into the opencode process environment, matching how `GITHUB_TOKEN` is exposed.
 
 ### Generating a Gitea Token
 
@@ -289,15 +291,18 @@ On startup, the entrypoint automatically injects the Gitea MCP server configurat
 2. Create a new token with the scopes you need (e.g., `repo`, `issue`, `admin:org`)
 3. Copy the token into `GITEA_TOKEN`
 
-### What the Agent Can Do
+### What You (and the Agent) Can Do
 
-With the Gitea MCP server, the AI agent can:
-- Create, list, and manage repositories
-- Create, edit, and search issues
-- Manage pull requests and code reviews
-- Work with branches, tags, and releases
-- Search code across repositories
-- Manage organizations and teams
+Once `tea` is authenticated, typical commands include:
+
+```bash
+tea repos list
+tea issues create --repo owner/repo --title "..." --body "..."
+tea pulls list --repo owner/repo
+tea releases create --repo owner/repo --tag v1.0.0
+```
+
+See `tea --help` or the [tea docs](https://gitea.com/gitea/tea) for the full command set.
 
 ## OpenCode Config
 
@@ -360,7 +365,7 @@ docker buildx build --platform linux/arm64 -t opencode-agent .
 | **Go** | 1.26.1 | Official binary |
 | **Git** | System | |
 | **GitHub CLI (gh)** | Latest | Authenticate with `GITHUB_TOKEN` env var |
-| **Gitea MCP** | Latest | Official Go binary, auto-configured via env vars |
+| **Gitea CLI (tea)** | 0.11.0 | Pinned prebuilt binary; authenticates via `GITEA_URL` + `GITEA_TOKEN` |
 | **OpenChamber** | 1.9.4 | `@openchamber/web` — optional control-room UI, enabled via `OPENCODE_MODE=openchamber` |
 | **node-gyp** | Latest | Native addon build tool (global) |
 | **yarn** | Latest | Alternative package manager (global) |
@@ -431,8 +436,8 @@ Docker and Dokploy will report the container as `healthy` once the primary servi
 | `OPENROUTER_API_KEY` | No | — | OpenRouter API key |
 | `GROQ_API_KEY` | No | — | Groq API key |
 | `GITHUB_TOKEN` | No | — | GitHub PAT for `gh` CLI. When set, the entrypoint also runs `gh auth setup-git` so `git push`/`git fetch` over HTTPS work non-interactively from the terminal. |
-| `GITEA_URL` | No | — | Gitea instance URL |
-| `GITEA_TOKEN` | No | — | Gitea personal access token |
+| `GITEA_URL` | No | — | Gitea instance URL. When set alongside `GITEA_TOKEN`, the entrypoint runs `tea login add --name default` so the `tea` CLI is authenticated non-interactively. |
+| `GITEA_TOKEN` | No | — | Gitea PAT for the `tea` CLI |
 | `SSH_PORT` | No | `2222` | Host port mapped to container SSH port 22 |
 
 > **Note:** Environment variables matching `AWS_*` and `AZURE_*` patterns are also automatically forwarded into the container.
@@ -578,12 +583,13 @@ docker exec -u coder <container> git config --global --get-regexp credential
 
 It should list a helper entry for `https://github.com`. This also silences OpenChamber's `Failed to filter active remote branches, returning all` warning in the branches panel.
 
-### Gitea MCP not working
+### Gitea `tea` CLI auth not working
 
 - Verify both `GITEA_URL` and `GITEA_TOKEN` are set
 - Check that the token has appropriate scopes in your Gitea instance
-- Inspect the generated config: `cat ~/.config/opencode/opencode.json`
-- Check container logs for "Gitea MCP server configured" message
+- List configured logins: `docker exec -u coder <container> tea login list`
+- Inspect the generated config: `docker exec -u coder <container> cat ~/.config/tea/config.yml`
+- Check container logs for the `Configured tea CLI login 'default' for …` line
 
 ### Dokploy network not found
 
@@ -595,7 +601,7 @@ This container bundles and builds on the work of several upstream open-source pr
 
 - **[opencode](https://opencode.ai)** — the terminal-native AI coding agent that powers every mode of this container.
 - **[OpenChamber](https://github.com/openchamber/openchamber)** by [@btriapitsyn](https://github.com/btriapitsyn) — the "control room" web UI enabled via `OPENCODE_MODE=openchamber`. Distributed as the `@openchamber/web` npm package.
-- **[Gitea MCP](https://gitea.com/gitea/gitea-mcp)** — the official Gitea MCP server for AI agent integration.
+- **[Gitea tea CLI](https://gitea.com/gitea/tea)** — the official Gitea command-line client, authenticated via `GITEA_URL` + `GITEA_TOKEN` on startup.
 - **[Dokploy](https://dokploy.com)** — the self-hosted PaaS this container is primarily designed to deploy on.
 
 All upstream projects retain their own licenses. This repository's glue code and Docker configuration are MIT-licensed — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ docker buildx build --platform linux/arm64 -t opencode-agent .
 | **Git** | System | |
 | **GitHub CLI (gh)** | Latest | Authenticate with `GITHUB_TOKEN` env var |
 | **Gitea CLI (tea)** | 0.11.0 | Pinned prebuilt binary; authenticates via `GITEA_URL` + `GITEA_TOKEN` |
-| **OpenChamber** | 1.9.4 | `@openchamber/web` — optional control-room UI, enabled via `OPENCODE_MODE=openchamber` |
+| **OpenChamber** | Latest at build time | `@openchamber/web` — optional control-room UI, enabled via `OPENCODE_MODE=openchamber`. Pinned to `latest`; pass `--build-arg CACHEBUST=$(date +%s)` (or a commit SHA) on rebuild to force a fresh pull |
 | **node-gyp** | Latest | Native addon build tool (global) |
 | **yarn** | Latest | Alternative package manager (global) |
 | **pnpm** | Latest | Fast, disk-efficient package manager (global) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - GIT_BRANCH=${GIT_BRANCH:-}
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
-      # Gitea MCP
+      # Gitea CLI (tea)
       - GITEA_URL=${GITEA_URL:-}
       - GITEA_TOKEN=${GITEA_TOKEN:-}
       # Server auth

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -315,30 +315,6 @@ if [ -n "${OPENCODE_CONFIG_JSON:-}" ]; then
     log_info "OpenCode config overridden from OPENCODE_CONFIG_JSON env var."
 fi
 
-# ==============================================================================
-# Gitea MCP Server
-# ==============================================================================
-if [ -n "${GITEA_URL:-}" ] && [ -n "${GITEA_TOKEN:-}" ]; then
-    GITEA_MCP_CONFIG=$(jq -n \
-        --arg host "$GITEA_URL" \
-        --arg token "$GITEA_TOKEN" \
-        '{
-            "type": "local",
-            "command": ["/usr/local/bin/gitea-mcp", "-t", "stdio"],
-            "enabled": true,
-            "environment": {
-                "GITEA_HOST": $host,
-                "GITEA_ACCESS_TOKEN": $token
-            }
-        }')
-
-    jq --argjson gitea "$GITEA_MCP_CONFIG" '.mcp.gitea = $gitea' \
-        "$OPENCODE_CONFIG_FILE" > "${OPENCODE_CONFIG_FILE}.tmp" \
-        && mv "${OPENCODE_CONFIG_FILE}.tmp" "$OPENCODE_CONFIG_FILE"
-    chown coder:coder "$OPENCODE_CONFIG_FILE"
-    log_info "Gitea MCP server configured for $GITEA_URL."
-fi
-
 # Ensure directories exist and are owned by coder
 mkdir -p /home/coder/.local/share/opencode
 chown -R coder:coder /home/coder/.local/share/opencode
@@ -388,6 +364,20 @@ if [ -n "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
     fi
 fi
 
+# When GITEA_URL+GITEA_TOKEN are set, configure the tea CLI non-interactively.
+# tea login add is not idempotent, so delete any existing entry first so token
+# rotations are picked up on reboot.
+if [ -n "${GITEA_URL:-}" ] && [ -n "${GITEA_TOKEN:-}" ] && command -v tea >/dev/null 2>&1; then
+    su - coder -c "tea login delete default" >/dev/null 2>&1 || true
+    TEA_URL_Q=$(printf %q "$GITEA_URL")
+    TEA_TOKEN_Q=$(printf %q "$GITEA_TOKEN")
+    if su - coder -c "tea login add --name default --url $TEA_URL_Q --token $TEA_TOKEN_Q" >/dev/null 2>&1; then
+        log_info "Configured tea CLI login 'default' for $GITEA_URL."
+    else
+        log_warn "tea login add failed — Gitea CLI auth not configured."
+    fi
+fi
+
 # ==============================================================================
 # Start Services
 # ==============================================================================
@@ -399,7 +389,7 @@ OPENCODE_ENV_FILE="/etc/profile.d/opencode-env.sh"
 : > "$OPENCODE_ENV_FILE"
 while IFS='=' read -r key val; do
     case "$key" in
-        OPENCODE_SERVER_*|ANTHROPIC_*|OPENAI_*|GOOGLE_*|OPENROUTER_*|GROQ_*|GITHUB_TOKEN|AWS_*|AZURE_*)
+        OPENCODE_SERVER_*|ANTHROPIC_*|OPENAI_*|GOOGLE_*|OPENROUTER_*|GROQ_*|GITHUB_TOKEN|GITEA_URL|GITEA_TOKEN|AWS_*|AZURE_*)
             printf 'export %s=%q\n' "$key" "$val" >> "$OPENCODE_ENV_FILE"
             ;;
     esac


### PR DESCRIPTION
Swap the injected Gitea MCP server for the official Gitea `tea` CLI, so
Gitea integration mirrors the lighter `gh` CLI pattern (env-var driven
auth wired up at entrypoint) rather than shipping a full MCP server.

The `GITEA_URL` / `GITEA_TOKEN` env-var contract is unchanged. On
startup the entrypoint now runs `tea login add --name default ...` as
coder, deleting any existing `default` login first so token rotations
take effect on restart. Both vars are also forwarded into opencode's
process env, matching how GITHUB_TOKEN is exposed.

Closes #22