### PR TITLE
fix: healthcheck accepts 401 in serve/web modes

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -12,6 +12,8 @@ case "$MODE" in
         curl -s -o /dev/null "http://localhost:${PORT}/" || exit 1
         ;;
     *)
-        curl -sf "http://localhost:${PORT}/doc" >/dev/null 2>&1 || exit 1
+        # Accept any HTTP response (including 401 when OPENCODE_SERVER_PASSWORD
+        # is set) since we only need to verify the server is listening.
+        curl -s -o /dev/null "http://localhost:${PORT}/doc" || exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- Healthcheck for `serve`/`web` modes used `curl -sf http://localhost:PORT/doc`, which fails on 4xx
- When `OPENCODE_SERVER_PASSWORD` is set, opencode returns 401 on every endpoint (including `/doc`), making the container `unhealthy`
- Reverse proxies (e.g. Traefik) silently skip unhealthy containers, so the public URL returns a default 404 with no obvious error
- Fix mirrors the `openchamber)` branch — drop `-f`, just verify the server is listening

## Test plan
- [x] `make lint`
- [ ] Redeploy with `OPENCODE_SERVER_PASSWORD` set, container reports healthy, reverse proxy registers the router, public URL returns the 401 Basic Auth challenge instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)