### PR TITLE
fix: harden entrypoint quoting, env forwarding, and sshd PID tracking

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.gitignore
+.dockerignore
+.env
+.env.example
+tests
+Makefile
+README.md
+LICENSE
+docker-compose.yml
+CLAUDE.md

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ ANTHROPIC_API_KEY=           # Anthropic API key
 OPENAI_API_KEY=              # OpenAI API key
 GOOGLE_API_KEY=              # Google Gemini API key
 OPENROUTER_API_KEY=          # OpenRouter API key
+GROQ_API_KEY=                # Groq API key
 
 # GitHub CLI (optional)
 GITHUB_TOKEN=                # GitHub personal access token for gh CLI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck
-        run: shellcheck -s bash entrypoint.sh
+        run: shellcheck -s bash entrypoint.sh healthcheck.sh
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ COPY entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /entrypoint.sh /healthcheck.sh
 
-EXPOSE 4096
+EXPOSE 4096 22
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD /healthcheck.sh

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 BATS := ./tests/bats/bin/bats
 SHELLCHECK := shellcheck
 
-.PHONY: test lint test-unit install-bats clean
+.PHONY: test lint test-unit install-bats build clean
 
 # Default: lint + unit tests
 test: lint test-unit
@@ -20,7 +20,7 @@ lint:
 
 # Unit tests (no Docker required)
 test-unit: install-bats
-	$(BATS) tests/test_logging.bats tests/test_validate_env.bats
+	$(BATS) tests/test_*.bats
 
 # Build Docker image (smoke test)
 build:

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ docker compose up -d
 # Remote TUI (serve mode): opencode attach http://localhost:4096
 ```
 
-> **Note:** When running standalone, you may need to add `ports` back to `docker-compose.yml` or use `docker exec` to access the container. See `env.example` for all configurable environment variables.
+> **Note:** See `.env.example` for all configurable environment variables — copy it to `.env` and fill in what you need.
 
 ## Access Modes
 
-The container supports three access modes, controlled by the `OPENCODE_MODE` environment variable:
+The container supports four access modes, controlled by the `OPENCODE_MODE` environment variable:
 
 ### Serve Mode (default)
 
@@ -406,6 +406,7 @@ On first start (when the `coder-home` volume is empty), the entrypoint copies a 
 
 The container includes a Docker HEALTHCHECK that adapts to the active mode:
 - **serve/web**: Checks the HTTP endpoint on the configured port
+- **openchamber**: Checks the OpenChamber UI on the configured port (any HTTP response counts, including 401 when a UI password is set)
 - **ssh**: Verifies the SSH daemon is accepting connections
 
 Docker and Dokploy will report the container as `healthy` once the primary service is ready.
@@ -492,15 +493,16 @@ make build
 
 ```
 tests/
-  test_helper.bash          # Shared setup: sources entrypoint functions
-  test_logging.bats         # Tests for log_info, log_warn, log_error
-  test_validate_env.bats    # Tests for all env validation paths (~33 tests)
+  test_helper.bash            # Shared setup: sources entrypoint functions
+  test_logging.bats           # Tests for log_info, log_warn, log_error
+  test_validate_env.bats      # Tests for all env validation paths
+  test_env_forwarding.bats    # Tests for the API-key env forwarding to opencode
 ```
 
 ### CI
 
 GitHub Actions runs on every push to `main` and on all pull requests:
-- **lint** — shellcheck on `entrypoint.sh`
+- **lint** — shellcheck on `entrypoint.sh` and `healthcheck.sh`
 - **unit-tests** — all bats test suites
 - **docker-build** — Docker image build smoke test
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ validate_env() {
 
     # Validate OPENCODE_PORT is a valid port number
     if [ -n "${OPENCODE_PORT:-}" ]; then
-        if ! echo "$OPENCODE_PORT" | grep -qE '^[0-9]+$' || \
+        if ! echo "$OPENCODE_PORT" | grep -qE '^[0-9]{1,5}$' || \
            [ "$OPENCODE_PORT" -lt 1 ] || [ "$OPENCODE_PORT" -gt 65535 ]; then
             log_error "Invalid OPENCODE_PORT='$OPENCODE_PORT'. Must be a number between 1 and 65535"
             errors=$((errors + 1))
@@ -131,6 +131,30 @@ validate_env() {
     log_info "Environment validation passed."
 }
 
+# ==============================================================================
+# OpenCode Env Forwarding
+# ==============================================================================
+# Write API keys and server config into a profile.d file so `su - coder`
+# login shells (which start opencode) inherit them. Reads the environment
+# NUL-delimited so multi-line values survive intact.
+write_opencode_env_file() {
+    local env_file="$1"
+    local kv key val
+    : > "$env_file"
+    while IFS= read -r -d '' kv; do
+        key="${kv%%=*}"
+        val="${kv#*=}"
+        # Only forward keys that are valid shell identifiers
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        case "$key" in
+            OPENCODE_SERVER_*|ANTHROPIC_*|OPENAI_*|GOOGLE_*|OPENROUTER_*|GROQ_*|GITHUB_TOKEN|GITEA_URL|GITEA_TOKEN|AWS_*|AZURE_*)
+                printf 'export %s=%q\n' "$key" "$val" >> "$env_file"
+                ;;
+        esac
+    done < <(env -0)
+    chmod 644 "$env_file"
+}
+
 # Guard: when sourced for testing, stop here and export only function definitions
 if [[ "${__SOURCED_FOR_TESTING:-}" == "true" ]]; then
     # shellcheck disable=SC2317
@@ -143,7 +167,7 @@ validate_env
 # First-boot Home Directory Initialization
 # ==============================================================================
 if [ ! -f /home/coder/.initialized ]; then
-    cp -rn /etc/skel.coder/. /home/coder/
+    cp -r --update=none /etc/skel.coder/. /home/coder/
     touch /home/coder/.initialized
     chown -R coder:coder /home/coder
     log_info "Initialized home directory from skeleton."
@@ -200,6 +224,20 @@ if [ "$OPENCODE_MODE" = "ssh" ] || [ "$SSH_ENABLED" = "true" ]; then
     SSH_NEEDED=true
 fi
 
+# Start sshd in the background and record its real PID for the cleanup trap.
+# sshd self-daemonizes (no `&`), so `$!` would capture an unrelated process —
+# read the PID from sshd's pidfile instead.
+start_background_sshd() {
+    log_info "Starting SSH server in background..."
+    /usr/sbin/sshd -e
+    local _
+    for _ in 1 2 3 4 5; do
+        [ -s /run/sshd.pid ] && break
+        sleep 0.1
+    done
+    SSHD_PID=$(cat /run/sshd.pid 2>/dev/null || true)
+}
+
 if [ "$SSH_NEEDED" = "true" ]; then
     # SSH Host Key Persistence
     HOST_KEY_DIR="/etc/ssh/host_keys"
@@ -229,7 +267,7 @@ if [ "$SSH_NEEDED" = "true" ]; then
     # SSH public key auth
     if [ -n "${SSH_PUBLIC_KEY:-}" ]; then
         mkdir -p /home/coder/.ssh
-        echo "$SSH_PUBLIC_KEY" > /home/coder/.ssh/authorized_keys
+        printf '%s\n' "$SSH_PUBLIC_KEY" > /home/coder/.ssh/authorized_keys
         chmod 700 /home/coder/.ssh
         chmod 600 /home/coder/.ssh/authorized_keys
         chown -R coder:coder /home/coder/.ssh
@@ -261,7 +299,7 @@ update_opencode() {
     # Get current version (handle missing binary gracefully)
     local current_version=""
     if [ -x "$OPENCODE_BIN" ]; then
-        current_version=$(su - coder -c "opencode --version" 2>/dev/null || echo "unknown")
+        current_version=$(su - coder -c "$OPENCODE_BIN --version" 2>/dev/null || echo "unknown")
     fi
     log_info "Current OpenCode version: ${current_version:-not installed}"
 
@@ -269,7 +307,7 @@ update_opencode() {
     if su - coder -c "curl -fsSL https://opencode.ai/install | bash" 2>/dev/null; then
         local new_version=""
         if [ -x "$OPENCODE_BIN" ]; then
-            new_version=$(su - coder -c "opencode --version" 2>/dev/null || echo "unknown")
+            new_version=$(su - coder -c "$OPENCODE_BIN --version" 2>/dev/null || echo "unknown")
         fi
 
         if [ "$current_version" != "$new_version" ]; then
@@ -310,7 +348,7 @@ fi
 
 # Override config from env var if provided
 if [ -n "${OPENCODE_CONFIG_JSON:-}" ]; then
-    echo "$OPENCODE_CONFIG_JSON" > "$OPENCODE_CONFIG_FILE"
+    printf '%s\n' "$OPENCODE_CONFIG_JSON" > "$OPENCODE_CONFIG_FILE"
     chown coder:coder "$OPENCODE_CONFIG_FILE"
     log_info "OpenCode config overridden from OPENCODE_CONFIG_JSON env var."
 fi
@@ -326,12 +364,14 @@ chown -R coder:coder /home/coder/.config
 if [ -n "${GIT_REPO_URL:-}" ]; then
     CLONE_DIR="/home/coder/workspace/$(basename "$GIT_REPO_URL" .git)"
     if [ ! -d "$CLONE_DIR" ]; then
-        BRANCH_FLAG=""
+        # Shell-escape everything interpolated into the su -c command line
+        CLONE_CMD="git clone"
         if [ -n "${GIT_BRANCH:-}" ]; then
-            BRANCH_FLAG="--branch $GIT_BRANCH"
+            CLONE_CMD="$CLONE_CMD --branch $(printf %q "$GIT_BRANCH")"
         fi
+        CLONE_CMD="$CLONE_CMD $(printf %q "$GIT_REPO_URL") $(printf %q "$CLONE_DIR")"
         log_info "Cloning $GIT_REPO_URL into $CLONE_DIR..."
-        if su - coder -c "git clone $BRANCH_FLAG '$GIT_REPO_URL' '$CLONE_DIR'"; then
+        if su - coder -c "$CLONE_CMD"; then
             log_info "Repository cloned successfully."
         else
             log_error "Failed to clone repository from $GIT_REPO_URL"
@@ -346,10 +386,10 @@ fi
 # Git Config
 # ==============================================================================
 if [ -n "${GIT_USER_NAME:-}" ]; then
-    su - coder -c "git config --global user.name '$GIT_USER_NAME'"
+    su - coder -c "git config --global user.name $(printf %q "$GIT_USER_NAME")"
 fi
 if [ -n "${GIT_USER_EMAIL:-}" ]; then
-    su - coder -c "git config --global user.email '$GIT_USER_EMAIL'"
+    su - coder -c "git config --global user.email $(printf %q "$GIT_USER_EMAIL")"
 fi
 
 # When GITHUB_TOKEN is set, wire gh as git's credential helper for github.com
@@ -386,15 +426,7 @@ OPENCODE_PORT="${OPENCODE_PORT:-4096}"
 # Forward API keys and server config to the opencode process.
 # su - coder starts a login shell that auto-sources /etc/profile.d/*.sh
 OPENCODE_ENV_FILE="/etc/profile.d/opencode-env.sh"
-: > "$OPENCODE_ENV_FILE"
-while IFS='=' read -r key val; do
-    case "$key" in
-        OPENCODE_SERVER_*|ANTHROPIC_*|OPENAI_*|GOOGLE_*|OPENROUTER_*|GROQ_*|GITHUB_TOKEN|GITEA_URL|GITEA_TOKEN|AWS_*|AZURE_*)
-            printf 'export %s=%q\n' "$key" "$val" >> "$OPENCODE_ENV_FILE"
-            ;;
-    esac
-done < <(env)
-chmod 644 "$OPENCODE_ENV_FILE"
+write_opencode_env_file "$OPENCODE_ENV_FILE"
 
 if [ -s "$OPENCODE_ENV_FILE" ]; then
     log_info "Forwarded env vars: $(grep -oP '(?<=export )\w+' "$OPENCODE_ENV_FILE" | tr '\n' ' ')"
@@ -405,18 +437,14 @@ fi
 case "$OPENCODE_MODE" in
     serve)
         if [ "$SSH_ENABLED" = "true" ]; then
-            log_info "Starting SSH server in background..."
-            /usr/sbin/sshd -e
-            SSHD_PID=$!
+            start_background_sshd
         fi
         log_info "Starting opencode server on port $OPENCODE_PORT..."
         exec su - coder -c "$OPENCODE_BIN serve --port $OPENCODE_PORT --hostname 0.0.0.0"
         ;;
     web)
         if [ "$SSH_ENABLED" = "true" ]; then
-            log_info "Starting SSH server in background..."
-            /usr/sbin/sshd -e
-            SSHD_PID=$!
+            start_background_sshd
         fi
         log_info "Starting opencode web UI on port $OPENCODE_PORT..."
         exec su - coder -c "$OPENCODE_BIN web --port $OPENCODE_PORT --hostname 0.0.0.0"
@@ -427,9 +455,7 @@ case "$OPENCODE_MODE" in
         ;;
     openchamber)
         if [ "$SSH_ENABLED" = "true" ]; then
-            log_info "Starting SSH server in background..."
-            /usr/sbin/sshd -e
-            SSHD_PID=$!
+            start_background_sshd
         fi
         log_info "Starting OpenChamber web UI on port $OPENCODE_PORT..."
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -9,11 +9,11 @@ case "$MODE" in
     openchamber)
         # Accept any HTTP response (including 401 when UI password is set)
         # since we only need to verify the server is listening.
-        curl -s -o /dev/null "http://localhost:${PORT}/" || exit 1
+        curl -s --max-time 4 -o /dev/null "http://localhost:${PORT}/" || exit 1
         ;;
     *)
         # Accept any HTTP response (including 401 when OPENCODE_SERVER_PASSWORD
         # is set) since we only need to verify the server is listening.
-        curl -s -o /dev/null "http://localhost:${PORT}/doc" || exit 1
+        curl -s --max-time 4 -o /dev/null "http://localhost:${PORT}/doc" || exit 1
         ;;
 esac

--- a/tests/test_env_forwarding.bats
+++ b/tests/test_env_forwarding.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+setup() {
+    load test_helper
+    ENV_FILE="$TEST_TMPDIR/opencode-env.sh"
+}
+
+teardown() {
+    teardown_helper
+}
+
+@test "write_opencode_env_file: forwards matching vars" {
+    export ANTHROPIC_API_KEY="sk-test-123"
+    write_opencode_env_file "$ENV_FILE"
+    unset ANTHROPIC_API_KEY
+    source "$ENV_FILE"
+    [ "$ANTHROPIC_API_KEY" = "sk-test-123" ]
+}
+
+@test "write_opencode_env_file: excludes non-matching vars" {
+    export MY_PRIVATE_SECRET="do-not-forward"
+    write_opencode_env_file "$ENV_FILE"
+    ! grep -q "MY_PRIVATE_SECRET" "$ENV_FILE"
+    unset MY_PRIVATE_SECRET
+}
+
+@test "write_opencode_env_file: preserves multi-line values" {
+    export AWS_TEST_CERT="-----BEGIN-----
+line2
+-----END-----"
+    write_opencode_env_file "$ENV_FILE"
+    local expected="$AWS_TEST_CERT"
+    unset AWS_TEST_CERT
+    source "$ENV_FILE"
+    [ "$AWS_TEST_CERT" = "$expected" ]
+}
+
+@test "write_opencode_env_file: multi-line values do not leak extra exports" {
+    export AWS_TEST_CERT="line1
+FAKE_INJECTED=oops"
+    write_opencode_env_file "$ENV_FILE"
+    unset AWS_TEST_CERT
+    ! grep -q '^export FAKE_INJECTED' "$ENV_FILE"
+    source "$ENV_FILE"
+    [ -z "${FAKE_INJECTED:-}" ]
+}
+
+@test "write_opencode_env_file: preserves special characters" {
+    export OPENCODE_SERVER_PASSWORD='p@$$ "word" '\''with'\'' spaces'
+    local expected="$OPENCODE_SERVER_PASSWORD"
+    write_opencode_env_file "$ENV_FILE"
+    unset OPENCODE_SERVER_PASSWORD
+    source "$ENV_FILE"
+    [ "$OPENCODE_SERVER_PASSWORD" = "$expected" ]
+}
+
+@test "write_opencode_env_file: values containing '=' survive" {
+    export GITEA_TOKEN="abc=def=ghi"
+    write_opencode_env_file "$ENV_FILE"
+    unset GITEA_TOKEN
+    source "$ENV_FILE"
+    [ "$GITEA_TOKEN" = "abc=def=ghi" ]
+}
+
+@test "write_opencode_env_file: truncates previous contents" {
+    echo "export STALE=1" > "$ENV_FILE"
+    write_opencode_env_file "$ENV_FILE"
+    ! grep -q "STALE" "$ENV_FILE"
+}
+
+@test "write_opencode_env_file: generated file is valid shell" {
+    export ANTHROPIC_API_KEY="sk-test"
+    export AWS_MULTILINE="a
+b"
+    write_opencode_env_file "$ENV_FILE"
+    bash -n "$ENV_FILE"
+}

--- a/tests/test_validate_env.bats
+++ b/tests/test_validate_env.bats
@@ -95,6 +95,13 @@ teardown() {
     [[ "$output" == *"Invalid OPENCODE_PORT"* ]]
 }
 
+@test "validate_env: rejects OPENCODE_PORT larger than 64-bit integers" {
+    export OPENCODE_PORT=99999999999999999999
+    run validate_env
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid OPENCODE_PORT"* ]]
+}
+
 @test "validate_env: rejects OPENCODE_PORT=-1" {
     export OPENCODE_PORT=-1
     run validate_env


### PR DESCRIPTION
Code review fixes across the container scripts:

entrypoint.sh
- Fix SSHD_PID capture: sshd self-daemonizes, so `$!` recorded the PID
  of the earlier <(env) process substitution instead of sshd. The three
  duplicated background-sshd blocks are now a single helper that reads
  the real PID from /run/sshd.pid.
- Fix env forwarding to opencode: values containing newlines were
  truncated and their continuation lines leaked as bogus exports into
  /etc/profile.d/opencode-env.sh. The loop now reads `env -0`
  NUL-delimited, and only forwards keys that are valid identifiers.
  Extracted into write_opencode_env_file() so it is unit-testable.
- Shell-escape GIT_REPO_URL, GIT_BRANCH, GIT_USER_NAME and
  GIT_USER_EMAIL before interpolating them into `su -c` command lines;
  a single quote in any of them previously broke out of the quoting.
- Reject OPENCODE_PORT values too large for shell integer comparison
  (e.g. 20 digits) instead of passing them to `[ -lt ]`.
- Replace deprecated `cp -rn` with `cp -r --update=none` (coreutils
  warns -n behavior may change).
- Use $OPENCODE_BIN instead of PATH lookup in update_opencode, and
  printf instead of echo when writing user-supplied content.

healthcheck.sh
- Add --max-time 4 to curl so a hung server fails the check cleanly
  within Docker's 5s healthcheck timeout.

CI / Makefile / Dockerfile
- Lint healthcheck.sh in CI (Makefile already did); run all
  tests/test_*.bats via glob; add build to .PHONY; add EXPOSE 22;
  add .dockerignore to keep .git/tests out of the build context.

Docs / examples
- README: four access modes (not three), .env.example filename,
  drop stale "add ports back" note, document openchamber healthcheck.
- .env.example: add missing GROQ_API_KEY.

tests
- New test_env_forwarding.bats (8 tests) covering multi-line values,
  special characters, '=' in values, exclusion and truncation.
- New validate_env test for oversized ports.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01THXid26JpTq61RUxStQafE